### PR TITLE
Harden BAFE API requests, validate onboarding inputs, and surface partial failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,7 @@
-# GEMINI_API_KEY: Required for Gemini AI API calls.
-# AI Studio automatically injects this at runtime from user secrets.
-# Users configure this via the Secrets panel in the AI Studio UI.
-GEMINI_API_KEY="MY_GEMINI_API_KEY"
+# VITE_GEMINI_API_KEY: Required for Gemini AI API calls in the frontend.
+# In local development create a .env.local with this key.
+VITE_GEMINI_API_KEY="MY_GEMINI_API_KEY"
 
-# APP_URL: The URL where this applet is hosted.
-# AI Studio automatically injects this at runtime with the Cloud Run service URL.
-# Used for self-referential links, OAuth callbacks, and API endpoints.
-APP_URL="MY_APP_URL"
+# VITE_BAFE_BASE_URL: Optional override for the BAFE API base URL.
+# Defaults to https://bafe-production.up.railway.app when omitted.
+VITE_BAFE_BASE_URL="https://bafe-production.up.railway.app"

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,26 @@
+# Offene Punkte / Restfehler
+
+## 1) Supabase-Anbindung fehlt vollständig
+- Im aktuellen Repository existiert keine Supabase-Client-Initialisierung, kein Auth-Flow, keine Persistenz-Layer und keine Nutzung von Supabase-Tabellen in den Runtime-Pfaden.
+- Das ist kein partieller Defekt, sondern eine fehlende Implementierung.
+
+**Auswirkung:**
+- Keine Speicherung von Onboarding-Daten, Charts oder Dashboard-Zuständen in einer Datenbank.
+- Keine serverseitige Nachvollziehbarkeit oder Benutzerzustands-Persistenz.
+
+**Empfohlene nachhaltige Lösung:**
+1. `@supabase/supabase-js` integrieren und dedizierten `src/services/supabase.ts` Client aufbauen.
+2. Datenmodell definieren (z. B. `profiles`, `birth_charts`, `interpretations`).
+3. Onboarding-Submit persistent speichern und Dashboard-Ladevorgang auf DB + Cache umstellen.
+4. Fehler- und Retry-Strategie für DB-Schreib-/Leseoperationen ergänzen.
+
+## 2) Live-Verifikation des externen BAFE-Endpunktes in dieser Laufumgebung nicht möglich
+- Ein direkter Laufzeit-Check gegen `https://bafe-production.up.railway.app` war aus der aktuellen Umgebung wegen Netzwerkfehler (`ENETUNREACH`) nicht möglich.
+- Die Endpoint-Schema-Prüfung wurde daher statisch anhand der Request-Payloads im Code durchgeführt und korrigiert.
+
+**Auswirkung:**
+- Die konkrete Serverantwort (inkl. möglicher Schema-Änderungen auf Serverseite) konnte nicht gegen die aktuelle Produktion validiert werden.
+
+**Empfohlene nachhaltige Lösung:**
+1. CI-Contract-Tests gegen eine erreichbare Staging-Instanz ergänzen.
+2. OpenAPI/JSON-Schema des BAFE-Backends versioniert einbinden und gegen Requests/Responses validieren.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/ddb522b7-094a-4769-b16a-b6e13
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `VITE_GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { BirthForm } from "./components/BirthForm";
 import { Dashboard } from "./components/Dashboard";
 import { Splash } from "./components/Splash";
-import { calculateAll, BirthData } from "./services/api";
+import { calculateAll, BirthData, ApiIssue } from "./services/api";
 import { generateInterpretation } from "./services/gemini";
 import { Volume2, VolumeX, User, Compass, LayoutGrid, Archive } from "lucide-react";
 
@@ -11,6 +11,7 @@ export default function App() {
   const [audioPlaying, setAudioPlaying] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [apiData, setApiData] = useState<any>(null);
+  const [apiIssues, setApiIssues] = useState<ApiIssue[]>([]);
   const [interpretation, setInterpretation] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -45,6 +46,7 @@ export default function App() {
     try {
       const results = await calculateAll(data);
       setApiData(results);
+      setApiIssues(results.issues);
 
       const aiInterpretation = await generateInterpretation(results);
       setInterpretation(aiInterpretation);
@@ -79,6 +81,7 @@ export default function App() {
     setApiData(null);
     setInterpretation(null);
     setError(null);
+    setApiIssues([]);
   };
 
   if (showSplash) {
@@ -121,6 +124,7 @@ export default function App() {
             onReset={handleReset}
             onRegenerate={handleRegenerate}
             isLoading={isLoading}
+            apiIssues={apiIssues}
           />
         )}
       </main>

--- a/src/components/BirthForm.tsx
+++ b/src/components/BirthForm.tsx
@@ -32,6 +32,18 @@ export function BirthForm({ onSubmit, isLoading }: BirthFormProps) {
       return;
     }
 
+    if (parsedLat < -90 || parsedLat > 90 || parsedLon < -180 || parsedLon > 180) {
+      alert("Koordinaten außerhalb des gültigen Bereichs. Breitengrad: -90 bis 90, Längengrad: -180 bis 180.");
+      return;
+    }
+
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: tz });
+    } catch {
+      alert("Ungültige Zeitzone. Bitte nutze eine IANA-Zeitzone wie Europe/Berlin.");
+      return;
+    }
+
     onSubmit({
       date: `${date}T${time}:00`,
       tz,

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ interface DashboardProps {
   onReset: () => void;
   onRegenerate: () => void;
   isLoading: boolean;
+  apiIssues: { endpoint: string; message: string }[];
 }
 
 export function Dashboard({
@@ -17,6 +18,7 @@ export function Dashboard({
   onReset,
   onRegenerate,
   isLoading,
+  apiIssues,
 }: DashboardProps) {
   useEffect(() => {
     // Load ElevenLabs widget script if not already loaded
@@ -104,6 +106,19 @@ export function Dashboard({
       >
         <ArrowLeft className="w-4 h-4" /> Start Over
       </button>
+
+      {apiIssues.length > 0 && (
+        <div className="mb-8 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-200">
+          Einige Berechnungen konnten nicht live geladen werden. Es wurden teilweise Fallback-Daten genutzt:
+          <ul className="mt-2 list-disc pl-4">
+            {apiIssues.map((issue) => (
+              <li key={`${issue.endpoint}-${issue.message}`}>
+                <span className="font-semibold">{issue.endpoint}</span>: {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <header className="mb-20 text-center md:text-left">
         <p className="text-gold/60 text-[9px] uppercase tracking-[0.5em] mb-4">Willkommen im Atlas</p>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,7 +5,21 @@ export interface BirthData {
   lat: number;
 }
 
-const BASE_URL = "https://bafe-production.up.railway.app";
+export interface ApiIssue {
+  endpoint: "bazi" | "western" | "fusion" | "wuxing" | "tst";
+  message: string;
+}
+
+export interface ApiResults {
+  bazi: unknown;
+  western: unknown;
+  fusion: unknown;
+  wuxing: unknown;
+  tst: unknown;
+  issues: ApiIssue[];
+}
+
+const BASE_URL = import.meta.env.VITE_BAFE_BASE_URL || "https://bafe-production.up.railway.app";
 
 const fetchWithTimeout = async (url: string, options: RequestInit, timeoutMs = 15000) => {
   const controller = new AbortController();
@@ -20,92 +34,97 @@ const fetchWithTimeout = async (url: string, options: RequestInit, timeoutMs = 1
   }
 };
 
-export async function calculateBazi(data: BirthData) {
-  const res = await fetchWithTimeout(`${BASE_URL}/calculate/bazi`, {
+function validateBirthData(data: BirthData) {
+  if (!data.date || !data.tz) {
+    throw new Error("Birth data is incomplete: date and timezone are required.");
+  }
+
+  if (!Number.isFinite(data.lat) || data.lat < -90 || data.lat > 90) {
+    throw new Error("Latitude must be a valid number between -90 and 90.");
+  }
+
+  if (!Number.isFinite(data.lon) || data.lon < -180 || data.lon > 180) {
+    throw new Error("Longitude must be a valid number between -180 and 180.");
+  }
+}
+
+async function postCalculation(endpoint: string, payload: Record<string, unknown>) {
+  const res = await fetchWithTimeout(`${BASE_URL}/calculate/${endpoint}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      date: data.date,
-      tz: data.tz,
-      lon: data.lon,
-      lat: data.lat,
-      standard: "CIVIL",
-      boundary: "midnight",
-      strict: true,
-      ambiguousTime: "earlier",
-      nonexistentTime: "error"
-    }),
+    body: JSON.stringify(payload),
   });
-  if (!res.ok) throw new Error("Failed to calculate Bazi");
+
+  if (!res.ok) {
+    const details = await res.text().catch(() => "No response body");
+    throw new Error(`Failed to calculate ${endpoint}: ${res.status} ${details}`);
+  }
+
   return res.json();
+}
+
+export async function calculateBazi(data: BirthData) {
+  validateBirthData(data);
+  return postCalculation("bazi", {
+    date: data.date,
+    tz: data.tz,
+    lon: data.lon,
+    lat: data.lat,
+    standard: "CIVIL",
+    boundary: "midnight",
+    strict: true,
+    ambiguousTime: "earlier",
+    nonexistentTime: "error",
+  });
 }
 
 export async function calculateWestern(data: BirthData) {
-  const res = await fetchWithTimeout(`${BASE_URL}/calculate/western`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      date: data.date,
-      tz: data.tz,
-      lon: data.lon,
-      lat: data.lat,
-      ambiguousTime: "earlier",
-      nonexistentTime: "error"
-    }),
+  validateBirthData(data);
+  return postCalculation("western", {
+    date: data.date,
+    tz: data.tz,
+    lon: data.lon,
+    lat: data.lat,
+    ambiguousTime: "earlier",
+    nonexistentTime: "error",
   });
-  if (!res.ok) throw new Error("Failed to calculate Western");
-  return res.json();
 }
 
 export async function calculateFusion(data: BirthData) {
-  const res = await fetchWithTimeout(`${BASE_URL}/calculate/fusion`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      date: data.date,
-      tz: data.tz,
-      lon: data.lon,
-      lat: data.lat,
-      ambiguousTime: "earlier",
-      nonexistentTime: "error",
-      bazi_pillars: null
-    }),
+  validateBirthData(data);
+  return postCalculation("fusion", {
+    date: data.date,
+    tz: data.tz,
+    lon: data.lon,
+    lat: data.lat,
+    ambiguousTime: "earlier",
+    nonexistentTime: "error",
+    bazi_pillars: null,
   });
-  if (!res.ok) throw new Error("Failed to calculate Fusion");
-  return res.json();
 }
 
 export async function calculateWuxing(data: BirthData) {
-  const res = await fetchWithTimeout(`${BASE_URL}/calculate/wuxing`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      date: data.date,
-      tz: data.tz,
-      lon: data.lon,
-      lat: data.lat,
-      ambiguousTime: "earlier",
-      nonexistentTime: "error"
-    }),
+  validateBirthData(data);
+  return postCalculation("wuxing", {
+    date: data.date,
+    tz: data.tz,
+    lon: data.lon,
+    lat: data.lat,
+    ambiguousTime: "earlier",
+    nonexistentTime: "error",
   });
-  if (!res.ok) throw new Error("Failed to calculate Wuxing");
-  return res.json();
 }
 
 export async function calculateTst(data: BirthData) {
-  const res = await fetchWithTimeout(`${BASE_URL}/calculate/tst`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      date: data.date,
-      tz: data.tz,
-      lon: data.lon,
-      ambiguousTime: "earlier",
-      nonexistentTime: "error"
-    }),
+  validateBirthData(data);
+  return postCalculation("tst", {
+    date: data.date,
+    tz: data.tz,
+    lon: data.lon,
+    lat: data.lat,
+    ambiguousTime: "earlier",
+    nonexistentTime: "error",
   });
-  if (!res.ok) throw new Error("Failed to calculate TST");
-  return res.json();
 }
 
 const MOCK_DATA = {
@@ -116,43 +135,46 @@ const MOCK_DATA = {
       year: { stem: "Jia", branch: "Chen" },
       month: { stem: "Bing", branch: "Yin" },
       day: { stem: "Wu", branch: "Wu" },
-      hour: { stem: "Ren", branch: "Zi" }
-    }
+      hour: { stem: "Ren", branch: "Zi" },
+    },
   },
   western: {
     zodiac_sign: "Aries",
     moon_sign: "Leo",
-    ascendant_sign: "Scorpio"
+    ascendant_sign: "Scorpio",
   },
   wuxing: {
-    dominant_element: "Fire"
+    dominant_element: "Fire",
   },
   fusion: {},
-  tst: {}
+  tst: {},
 };
 
-export async function calculateAll(data: BirthData) {
+export async function calculateAll(data: BirthData): Promise<ApiResults> {
+  const issues: ApiIssue[] = [];
+
+  const withFallback = async <T>(
+    endpoint: ApiIssue["endpoint"],
+    fn: () => Promise<T>,
+    fallback: T,
+  ): Promise<T> => {
+    try {
+      return await fn();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      issues.push({ endpoint, message });
+      console.warn(`${endpoint} API failed, using mock data:`, error);
+      return fallback;
+    }
+  };
+
   const [bazi, western, fusion, wuxing, tst] = await Promise.all([
-    calculateBazi(data).catch((e) => {
-      console.warn("BaZi API failed, using mock data:", e);
-      return MOCK_DATA.bazi;
-    }),
-    calculateWestern(data).catch((e) => {
-      console.warn("Western API failed, using mock data:", e);
-      return MOCK_DATA.western;
-    }),
-    calculateFusion(data).catch((e) => {
-      console.warn("Fusion API failed, using mock data:", e);
-      return MOCK_DATA.fusion;
-    }),
-    calculateWuxing(data).catch((e) => {
-      console.warn("WuXing API failed, using mock data:", e);
-      return MOCK_DATA.wuxing;
-    }),
-    calculateTst(data).catch((e) => {
-      console.warn("TST API failed, using mock data:", e);
-      return MOCK_DATA.tst;
-    }),
+    withFallback("bazi", () => calculateBazi(data), MOCK_DATA.bazi),
+    withFallback("western", () => calculateWestern(data), MOCK_DATA.western),
+    withFallback("fusion", () => calculateFusion(data), MOCK_DATA.fusion),
+    withFallback("wuxing", () => calculateWuxing(data), MOCK_DATA.wuxing),
+    withFallback("tst", () => calculateTst(data), MOCK_DATA.tst),
   ]);
-  return { bazi, western, fusion, wuxing, tst };
+
+  return { bazi, western, fusion, wuxing, tst, issues };
 }

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -1,8 +1,9 @@
 import { GoogleGenAI } from "@google/genai";
 
-const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+const apiKey = import.meta.env.VITE_GEMINI_API_KEY || "";
+const ai = apiKey ? new GoogleGenAI({ apiKey }) : null;
 
-export async function generateInterpretation(data: any) {
+export async function generateInterpretation(data: unknown) {
   const prompt = `
 You are Levi Bazi, an expert astrological AI agent. I have calculated the Western astrology, Chinese BaZi, and Wu-Xing (Five Elements) for a user using the BAFE API.
 Here is the data:
@@ -15,8 +16,13 @@ Provide actionable advice or a plausible horoscope reading based on these combin
 Keep it under 250 words. Write it directly to the user (e.g., "Your cosmic blueprint reveals...").
 `;
 
+  if (!ai) {
+    console.warn("Missing VITE_GEMINI_API_KEY. Using fallback interpretation.");
+    return "Dein kosmisches Blueprint offenbart eine faszinierende Mischung aus westlicher und östlicher Astrologie. Deine Sonnen-Signatur verleiht dir einen starken Willen, während dein Mond-Echo deine emotionale Tiefe prägt. Dein Aszendent zeigt, wie du der Welt begegnest. Im chinesischen System bringt dein Jahrestier besondere Eigenschaften mit sich, die von deinem dominanten Element verstärkt werden. Diese einzigartige Kombination macht dich zu dem, was du bist. Nutze diese Energien, um deinen Weg mit Klarheit und Zuversicht zu gehen.";
+  }
+
   try {
-    const response = await Promise.race([
+    const response = (await Promise.race([
       ai.models.generateContent({
         model: "gemini-3-flash-preview",
         contents: prompt,
@@ -24,10 +30,12 @@ Keep it under 250 words. Write it directly to the user (e.g., "Your cosmic bluep
           temperature: 0.7,
         },
       }),
-      new Promise((_, reject) => setTimeout(() => reject(new Error("Gemini API timeout")), 15000))
-    ]) as any;
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("Gemini API timeout")), 15000),
+      ),
+    ])) as { text?: string };
 
-    return response.text;
+    return response.text ?? "";
   } catch (error) {
     console.warn("Gemini API failed or timed out, using fallback interpretation:", error);
     return "Dein kosmisches Blueprint offenbart eine faszinierende Mischung aus westlicher und östlicher Astrologie. Deine Sonnen-Signatur verleiht dir einen starken Willen, während dein Mond-Echo deine emotionale Tiefe prägt. Dein Aszendent zeigt, wie du der Welt begegnest. Im chinesischen System bringt dein Jahrestier besondere Eigenschaften mit sich, die von deinem dominanten Element verstärkt werden. Diese einzigartige Kombination macht dich zu dem, was du bist. Nutze diese Energien, um deinen Weg mit Klarheit und Zuversicht zu gehen.";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GEMINI_API_KEY?: string;
+  readonly VITE_BAFE_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
### Motivation
- Behebe Inkonsistenzen im API-Request-Schema zum externen BAFE-Service und verhindere stilles Maskieren von Fehlern durch Mock-Fallbacks.
- Erhöhe Robustheit des Onboarding→Dashboard-Flows durch Eingabevalidierung (Koordinaten, Zeitzone) und sauberes Fehler-Handling.
- Stelle Frontend-Konfiguration für Gemini/BaFE über Vite-Umgebungsvariablen sicher und dokumentiere verbleibende systemweite Lücken.

### Description
- Zentralisierte POST-Logik und Fehlerbehandlung in `src/services/api.ts` (`postCalculation`, `validateBirthData`) und korrigierte Payloads (inkl. `lat` für `tst`).
- Sammlung und Rückgabe von Partial-Fehlern als `issues` in `ApiResults` statt stiller Console-Fallbacks, und Weitergabe an die UI.
- UI-Änderungen: `src/App.tsx` übergibt `apiIssues` an `Dashboard`, und `src/components/Dashboard.tsx` zeigt eine erklärende Warnung mit betroffenen Endpoints/Fehlermeldungen an.
- Onboarding-Härten: `src/components/BirthForm.tsx` validiert Koordinatenbereiche und prüft IANA-Zeitzonen vor Submit.
- Gemini-Initsicherung: `src/services/gemini.ts` liest `VITE_GEMINI_API_KEY` aus `import.meta.env`, nutzt sauberen Fallback wenn Key fehlt, und `src/vite-env.d.ts` ergänzt Vite-Typen.
- Dokumentation und Konfiguration: `.env.example` und `README.md` an Vite-Variablen angepasst und `BUGS.md` mit verbleibenden Problemen (u.a. fehlende Supabase-Implementierung und fehlende Live-Verifikation wegen Netzwerkrestriktion) hinzugefügt.

### Testing
- `npm run lint` wurde ausgeführt und erfolgreich (Typprüfung nach Ergänzung von `src/vite-env.d.ts`).
- `npm run build` wurde ausgeführt und erfolgreich (Vite-Build ohne TypeScript-Fehler; chunk-size Warnung ist informativ).
- Dev-Server gestartet mit `npm run dev` und ein visueller Onboarding-Flow-Screenshot wurde per Playwright erstellt (UI-Check erfolgreich).
- Direkte Live-Requests gegen `https://bafe-production.up.railway.app` schlugen in dieser Umgebung fehl mit `ENETUNREACH`, daher konnte die Produktion nicht runtime-verifiziert werden (siehe `BUGS.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699dd0a014f48322903208c646c69ae3)

## Summary by Sourcery

Harden external BAFE and Gemini integrations, validate onboarding inputs, and surface partial backend failures to the user.

New Features:
- Expose structured API issues from batched BAFE calculations and display them as a warning in the dashboard when fallbacks are used.

Bug Fixes:
- Align BAFE calculation payloads and base URL with environment configuration, including sending latitude for TST requests, to match the external service schema.

Enhancements:
- Centralize BAFE POST logic with shared validation and richer error messages for individual endpoints.
- Validate birth coordinate ranges and IANA time zones on the client before submitting onboarding data.
- Make Gemini usage resilient to missing API keys or timeouts by using Vite env configuration and a safe textual fallback interpretation.

Documentation:
- Update README and .env example to document Vite-based environment variables for Gemini and BAFE, and add BUGS.md describing known gaps such as missing Supabase integration and lack of live BAFE verification.