### PR TITLE
Fallback proxy for BAFE calculate endpoints and preserve dev proxy path

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -46,6 +46,48 @@ async function proxyToBafe(targetUrl, req, res) {
   }
 }
 
+async function proxyToBafeWithFallback(targetUrls, req, res) {
+  let lastResponse = null;
+
+  for (const targetUrl of targetUrls) {
+    console.log(`[proxy] trying ${req.method} ${targetUrl}`);
+    try {
+      const upstream = await fetch(targetUrl, {
+        method: req.method,
+        headers: { "Content-Type": "application/json" },
+        body: req.method === "GET" ? undefined : JSON.stringify(req.body),
+      });
+
+      if (upstream.status === 404) {
+        const body = await upstream.text();
+        console.warn(`[proxy] 404 at ${targetUrl}: ${body.slice(0, 200)}`);
+        lastResponse = { status: upstream.status, body, contentType: upstream.headers.get("content-type") || "application/json" };
+        continue;
+      }
+
+      const contentType = upstream.headers.get("content-type") || "application/json";
+      const body = await upstream.text();
+
+      if (!upstream.ok) {
+        console.error(`[proxy] → ${upstream.status}  body: ${body.slice(0, 300)}`);
+      }
+
+      return res.status(upstream.status).set("Content-Type", contentType).send(body);
+    } catch (err) {
+      console.error(`[proxy] network error on ${targetUrl}:`, err.message);
+    }
+  }
+
+  if (lastResponse) {
+    return res.status(lastResponse.status).set("Content-Type", lastResponse.contentType).send(lastResponse.body);
+  }
+
+  res.status(502).json({
+    error: "BAFE API unreachable",
+    details: "All fallback endpoints failed",
+  });
+}
+
 // ── /calculate/:endpoint  (bazi, western, fusion, wuxing, tst) ──────
 const CALC_ENDPOINTS = ["bazi", "western", "fusion", "wuxing", "tst"];
 
@@ -54,7 +96,14 @@ app.post("/api/calculate/:endpoint", express.json(), (req, res) => {
   if (!CALC_ENDPOINTS.includes(endpoint)) {
     return res.status(400).json({ error: `Unknown endpoint: ${endpoint}` });
   }
-  proxyToBafe(`${BAFE_BASE_URL}/calculate/${endpoint}`, req, res);
+  proxyToBafeWithFallback(
+    [
+      `${BAFE_BASE_URL}/api/calculate/${endpoint}`,
+      `${BAFE_BASE_URL}/calculate/${endpoint}`,
+    ],
+    req,
+    res,
+  );
 });
 
 // ── /chart ──────────────────────────────────────────────────────────
@@ -82,6 +131,7 @@ app.get("/api/debug-bafe", async (_req, res) => {
     { label: "/health", method: "GET", url: `${BAFE_BASE_URL}/health` },
     { label: "/chart", method: "GET", url: `${BAFE_BASE_URL}/chart` },
     { label: "/api/webhook/chart", method: "GET", url: `${BAFE_BASE_URL}/api/webhook/chart` },
+    { label: "POST /api/calculate/western", method: "POST", url: `${BAFE_BASE_URL}/api/calculate/western` },
     { label: "POST /calculate/western", method: "POST", url: `${BAFE_BASE_URL}/calculate/western` },
   ];
 

--- a/server.mjs
+++ b/server.mjs
@@ -58,21 +58,23 @@ async function proxyToBafeWithFallback(targetUrls, req, res) {
         body: req.method === "GET" ? undefined : JSON.stringify(req.body),
       });
 
-      if (upstream.status === 404) {
-        const body = await upstream.text();
-        console.warn(`[proxy] 404 at ${targetUrl}: ${body.slice(0, 200)}`);
-        lastResponse = { status: upstream.status, body, contentType: upstream.headers.get("content-type") || "application/json" };
-        continue;
-      }
-
       const contentType = upstream.headers.get("content-type") || "application/json";
       const body = await upstream.text();
 
-      if (!upstream.ok) {
+      if (upstream.ok) {
+        // Successful response: return immediately and do not try further fallbacks
+        return res.status(upstream.status).set("Content-Type", contentType).send(body);
+      }
+
+      if (upstream.status === 404) {
+        console.warn(`[proxy] 404 at ${targetUrl}: ${body.slice(0, 200)}`);
+      } else {
         console.error(`[proxy] → ${upstream.status}  body: ${body.slice(0, 300)}`);
       }
 
-      return res.status(upstream.status).set("Content-Type", contentType).send(body);
+      // Record the last non-ok response and try the next fallback URL
+      lastResponse = { status: upstream.status, body, contentType };
+      continue;
     } catch (err) {
       console.error(`[proxy] network error on ${targetUrl}:`, err.message);
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig(({mode}) => {
         '/api/calculate': {
           target: env.VITE_BAFE_BASE_URL || 'https://bafe.vercel.app',
           changeOrigin: true,
-          rewrite: (p: string) => p.replace(/^\/api/, ''),
         },
       },
     },


### PR DESCRIPTION
### Motivation
- Fix 404s observed for calculate endpoints (`bazi`, `western`, `fusion`, `wuxing`, `tst`) caused by mismatched upstream route variants between the frontend dev proxy and the BAFE service.

### Description
- Stop rewriting `/api/calculate` in `vite.config.ts` so the dev proxy preserves the `/api/calculate/*` prefix and forwards requests as expected.
- Add `proxyToBafeWithFallback` to `server.mjs` that iterates multiple upstream URLs and returns the first successful response while preserving non-404 upstream bodies.
- Switch the `/api/calculate/:endpoint` handler to use the fallback proxy and add both `${BAFE_BASE_URL}/api/calculate/:endpoint` and `${BAFE_BASE_URL}/calculate/:endpoint` as upstream candidates.
- Extend the `/api/debug-bafe` probe list to test both calculate route variants for easier diagnostics.

### Testing
- Ran `npm run build` which completed successfully (Vite production build finished and `dist/` was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699e92d00af88322bf3982808f885606)

## Summary by Sourcery

Add a fallback-aware proxy for BAFE calculate endpoints and align dev proxy routing to match backend route variants.

Bug Fixes:
- Ensure /api/calculate endpoints correctly reach BAFE regardless of whether the backend exposes /api/calculate or /calculate paths.

Enhancements:
- Introduce a proxy helper that iterates multiple upstream URLs, returning the first successful response while preserving 404 bodies from upstream.
- Extend the /api/debug-bafe diagnostics to probe both calculate route variants for easier debugging.

Build:
- Adjust Vite dev server proxy configuration to stop rewriting /api/calculate so requests keep their original prefix.