### PR TITLE
Fix returning-user onboarding flow and add ElevenLabs profile endpoint diagnostics

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -201,11 +201,12 @@ const supabaseAdmin = SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY
 
 // ── GET /api/profile/:userId — ElevenLabs Custom Tool endpoint ──────
 app.get("/api/profile/:userId", async (req, res) => {
-  // Auth: require Bearer token (ElevenLabs tool secret or session token)
+  // Auth: require Bearer token (ElevenLabs tool secret)
   const authHeader = req.headers.authorization || "";
   const token = authHeader.replace("Bearer ", "");
 
   if (!token || token !== ELEVENLABS_TOOL_SECRET) {
+    console.warn(`[elevenlabs] unauthorized profile access for user ${req.params.userId}`);
     return res.status(401).json({ error: "Unauthorized" });
   }
 
@@ -221,9 +222,11 @@ app.get("/api/profile/:userId", async (req, res) => {
     .single();
 
   if (error || !data) {
+    console.warn(`[elevenlabs] profile not found for user ${userId}`);
     return res.status(404).json({ error: "Profile not found" });
   }
 
+  console.log(`[elevenlabs] profile delivered for user ${userId}`);
   res.json({
     user_id: data.user_id,
     sun_sign: data.sun_sign,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [lastBirthInput, setLastBirthInput] = useState<BirthData | null>(null);
   const [profileLoading, setProfileLoading] = useState(false);
+  const [hasStoredProfile, setHasStoredProfile] = useState(false);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -43,6 +44,7 @@ export default function App() {
     setProfileLoading(true);
     fetchAstroProfile(user.id)
       .then((profile) => {
+        setHasStoredProfile(!!profile);
         if (profile?.astro_json) {
           const json = profile.astro_json as any;
           setApiData({
@@ -53,7 +55,10 @@ export default function App() {
             tst: json.tst,
             issues: [],
           });
-          setInterpretation(json.interpretation || null);
+          setInterpretation(
+            json.interpretation ||
+              "Dein gespeichertes Chart wurde geladen. Du kannst jederzeit unten eine neue KI-Deutung erzeugen.",
+          );
           if (profile.birth_date) {
             setLastBirthInput({
               date: `${profile.birth_date}T${profile.birth_time || "12:00"}`,
@@ -161,6 +166,7 @@ export default function App() {
     setError(null);
     setApiIssues([]);
     setLastBirthInput(null);
+    setHasStoredProfile(false);
   };
 
   const handleSignOut = async () => {
@@ -170,7 +176,7 @@ export default function App() {
 
   // Determine what to show
   const isLoggedIn = !!user;
-  const hasDashboard = apiData && interpretation;
+  const hasDashboard = !!apiData;
 
   return (
     <>
@@ -280,7 +286,7 @@ export default function App() {
                 <BirthForm onSubmit={handleSubmit} isLoading={isLoading} />
               ) : (
                 <Dashboard
-                  interpretation={interpretation}
+                  interpretation={interpretation || ""}
                   apiData={apiData}
                   onReset={handleReset}
                   onRegenerate={handleRegenerate}
@@ -295,6 +301,12 @@ export default function App() {
                     }
                   }}
                 />
+              )}
+
+              {!profileLoading && !hasDashboard && hasStoredProfile && (
+                <p className="mt-6 text-center text-xs text-white/40">
+                  Dein Account wurde gefunden, aber es liegt noch kein vollständiges Astro-Profil vor.
+                </p>
               )}
             </>
           )}


### PR DESCRIPTION
### Motivation
- Returning users with stored charts were incorrectly shown the birthdate onboarding because the UI required both `apiData` and `interpretation` to render the dashboard.\
- It's necessary to add server-side logs to the ElevenLabs profile endpoint to diagnose why the Levi agent may not be calling the custom tool or why it receives no profile.\

### Description
- Updated `src/App.tsx` to base dashboard visibility on the presence of `apiData` only by changing `hasDashboard` to `!!apiData` and added `hasStoredProfile` state to detect legacy accounts.\
- When loading a stored profile the app now sets a fallback interpretation string if `astro_json.interpretation` is missing, preventing legacy entries from being treated as incomplete.\
- Added a small UI hint shown when an account exists but no complete astro profile is present to make the state clearer to users.\
- Added `console.warn`/`console.log` diagnostics to `GET /api/profile/:userId` in `server.mjs` to log unauthorized access attempts, missing profiles, and successful deliveries to help troubleshoot the ElevenLabs agent tool calls.\

### Testing
- Ran a production build with `npm run build` and the Vite build completed successfully.\
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app loaded.\
- Captured a Playwright screenshot of the running app to validate the main surface and login flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a191165af48322812f7247e5900669)

## Summary by Sourcery

Fix returning-user onboarding so stored charts show the dashboard without requiring an interpretation and add diagnostics for the ElevenLabs profile API endpoint.

New Features:
- Show a hint message when a stored account exists but no complete astro profile is available.

Bug Fixes:
- Base dashboard visibility solely on the presence of API profile data so returning users with stored charts are not forced through birthdate onboarding.
- Provide a fallback interpretation message when loading legacy stored profiles that lack an interpretation field so they are not treated as incomplete.

Enhancements:
- Pass an empty interpretation string to the dashboard component when none is available to simplify rendering logic.

Chores:
- Log unauthorized, missing, and successful profile deliveries in the ElevenLabs profile endpoint to aid debugging of agent tool calls.