### PR TITLE
fix: repair SyntaxError in server.mjs that crashes server on every startup

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -170,12 +170,13 @@ const PROFILE_SELECT_FIELDS = [
   "astro_computed_at",
 ].join(", ");
 
-app.get("/api/profile/:userId", async (req, res) => {
+function requireToolAuth(req, res) {
   const authHeader = req.headers.authorization || "";
   const token = authHeader.replace("Bearer ", "");
   if (!token || token !== ELEVENLABS_TOOL_SECRET) {
     console.warn("[elevenlabs] unauthorized profile access", req.params.userId);
-    return res.status(401).json({ error: "Unauthorized" });
+    res.status(401).json({ error: "Unauthorized" });
+    return false;
   }
   if (!supabaseAdmin) {
     res.status(503).json({ error: "Supabase not configured on server" });


### PR DESCRIPTION
commit baea0d8 accidentally wrote the requireToolAuth auth logic as a
bare app.get() route handler with a missing closing ')'. Node.js cannot
parse the file at all (SyntaxError: missing ) after argument list at
line 185), so the server crashes immediately on every startup/deploy.

Fix: convert the broken route-handler block into a proper
requireToolAuth() function, and keep the single app.get() route below
it that already calls requireToolAuth correctly.

https://claude.ai/code/session_0178jgJxWEJ7SNjpDEVqBiRV

## Summary by Sourcery

Fix server startup failure by restoring proper authentication helper usage for the profile API route.

Bug Fixes:
- Resolve a syntax error in server.mjs that prevented Node.js from starting the server due to an unterminated route handler.
- Ensure unauthorized profile access is correctly handled without crashing the server.