### PR TITLE
fix: remove dead audioRef code that caused ReferenceError and blank s…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,14 +32,6 @@ export default function App() {
   const [profileLoading, setProfileLoading] = useState(false);
   const [hasStoredProfile, setHasStoredProfile] = useState(false);
 
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-
-  useEffect(() => {
-    audioRef.current = document.getElementById(
-      "cosmic-audio",
-    ) as HTMLAudioElement;
-  }, []);
-
   // Load existing astro profile for returning users
   useEffect(() => {
     if (!user || apiData) return;


### PR DESCRIPTION
…creen

Commit a651c66 removed useRef from React imports when introducing the useAmbientePlayer hook, but forgot to delete the old audioRef block (useRef call + useEffect that fetched #cosmic-audio from the DOM).

At runtime React throws "ReferenceError: useRef is not defined", crashing the app before render → completely black screen with no splash, no intro video, no navigation.

Remove the 7 dead lines. All audio is now handled by useAmbientePlayer.

https://claude.ai/code/session_0178jgJxWEJ7SNjpDEVqBiRV

## Summary by Sourcery

Bug Fixes:
- Fix a runtime ReferenceError caused by using useRef without importing it, which previously crashed the app before initial render.