### PR TITLE
fix: relax GEMINI boot requirement and allow ElevenLabs widget host in CSP

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -64,7 +64,7 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-inline'", "https://maps.googleapis.com", "https://elevenlabs.io", "https://unpkg.com"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://maps.googleapis.com", "https://elevenlabs.io", "https://unpkg.com/@elevenlabs/convai-widget-embed"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "blob:", "https:"],


### PR DESCRIPTION
### Motivation
- Prevent the entire web server from exiting when `GEMINI_API_KEY` is not provisioned and allow the ElevenLabs Levi widget script to load in production.

### Description
- Removed `GEMINI_API_KEY` from the hard `REQUIRED_ENV_VARS` list and added it to the optional warnings in `server.mjs` so the server can start without it.
- Added `https://unpkg.com` to the `helmet` CSP `scriptSrc` directive in `server.mjs` to permit loading `@elevenlabs/convai-widget-embed` from unpkg.

### Testing
- Ran `node --check server.mjs` which completed successfully; `server.mjs` syntax validated. 
- Ran `npm run lint` which failed due to pre-existing TypeScript/module-resolution errors in unrelated `features/plan/...` paths and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af6ddde1c083228b77b1b67b8ad321)

## Summary by Sourcery

Relax boot-time environment variable requirements and update content security policy for external widget loading.

Bug Fixes:
- Allow the server to start without a configured GEMINI_API_KEY by treating it as optional rather than required.

Enhancements:
- Log GEMINI_API_KEY as an optional environment variable whose absence may degrade specific features instead of stopping the server.
- Permit loading the ElevenLabs Convai widget bundle from unpkg by adding https://unpkg.com to the CSP script-src directive.