### PR TITLE
fix: prevent mobile dashboard from appearing all-black

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -455,7 +455,7 @@ function AppShell({ user, lang, setLang, t, siteVisible, planetariumMode, toggle
       </header>
 
       {/* ── Main content (routed) ──────────────────────────────────────── */}
-      <main className="flex-grow pt-24 md:pt-32 pb-24 md:pb-20 relative z-10 container mx-auto px-4 flex flex-col items-center justify-center">
+      <main className="flex-grow pt-6 md:pt-32 pb-24 md:pb-20 relative z-10 container mx-auto px-4 flex flex-col items-center justify-center">
         {error && (
           <div className="w-full max-w-md mb-8 bg-red-100 border border-red-300 text-red-700 px-4 py-3 rounded-xl text-sm text-center">
             {error}

--- a/src/components/BirthChartOrrery.tsx
+++ b/src/components/BirthChartOrrery.tsx
@@ -98,7 +98,6 @@ function makeConNameSprite(text: string): THREE.Sprite {
 // ─── Props ────────────────────────────────────────────────────────────────────
 interface BirthChartOrreryProps {
   birthDate: Date;
-  height?: string;
   planetariumMode?: boolean;
   birthConstellation?: string;
   /** Auto-start time-lapse on mount (first visit experience) */
@@ -111,7 +110,6 @@ interface BirthChartOrreryProps {
 
 export function BirthChartOrrery({
   birthDate,
-  height = '460px',
   planetariumMode = false,
   birthConstellation,
   autoPlay = false,
@@ -514,6 +512,32 @@ export function BirthChartOrrery({
     el.addEventListener('mousemove',  onMouseMove);
     el.addEventListener('wheel',      onWheel, { passive: false });
 
+    // ── Touch events (mobile) ────────────────────────────────────────────
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        isDragging.current = true;
+        lastMouse.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      }
+    };
+    const onTouchEnd = () => { isDragging.current = false; };
+    const onTouchMove = (e: TouchEvent) => {
+      if (!isDragging.current || e.touches.length !== 1) return;
+      e.preventDefault();
+      const dx = e.touches[0].clientX - lastMouse.current.x;
+      const dy = e.touches[0].clientY - lastMouse.current.y;
+      lastMouse.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      if (viewModeRef.current === 'orrery') {
+        sphT.current.theta -= dx * 0.005;
+        sphT.current.phi = Math.max(0.1, Math.min(Math.PI - 0.1, sphT.current.phi + dy * 0.005));
+      } else if (viewModeRef.current === 'planetarium') {
+        planLook.current.azimuth  = (planLook.current.azimuth - dx * 0.20 + 360) % 360;
+        planLook.current.altitude = Math.max(-5, Math.min(88, planLook.current.altitude - dy * 0.15));
+      }
+    };
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchend',   onTouchEnd);
+    el.addEventListener('touchmove',  onTouchMove, { passive: false });
+
     // ════════════════════════════════════════════════════════════════════════
     // ANIMATION LOOP
     // ════════════════════════════════════════════════════════════════════════
@@ -803,6 +827,9 @@ export function BirthChartOrrery({
       el.removeEventListener('mouseleave', onMouseLeave);
       el.removeEventListener('mousemove',  onMouseMove);
       el.removeEventListener('wheel',      onWheel);
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchend',   onTouchEnd);
+      el.removeEventListener('touchmove',  onTouchMove);
       renderer.dispose();
       if (el.contains(renderer.domElement)) el.removeChild(renderer.domElement);
     };
@@ -898,7 +925,8 @@ export function BirthChartOrrery({
       {/* Three.js Canvas */}
       <div
         ref={containerRef}
-        style={{ width: '100%', height, cursor: planetariumMode ? 'crosshair' : 'grab' }}
+        className="w-full h-[260px] md:h-[460px]"
+        style={{ cursor: planetariumMode ? 'crosshair' : 'grab' }}
       />
     </div>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -453,7 +453,6 @@ export function Dashboard({
       <motion.div className="mb-14" {...fadeIn(0.1)}>
         <BirthChartOrrery
           birthDate={orreryDate}
-          height="460px"
           planetariumMode={planetariumMode}
           birthConstellation={birthConstellationKey}
           autoPlay={showBirthSkyWelcome}


### PR DESCRIPTION
On small mobile screens (~667px tall), the combination of pt-24 (96px
of unused top padding — no mobile header exists) plus the 460px orrery
canvas consumed the entire viewport, leaving users staring at a
dark/black 3D canvas with no dashboard content visible above the fold.

Changes:
- BirthChartOrrery: replace fixed 460px height with responsive
  h-[260px] md:h-[460px] Tailwind classes; remove `height` prop
- BirthChartOrrery: add touchstart/touchmove/touchend handlers so
  the orrery is interactive on mobile (drag to rotate/look around)
- AppShell main: reduce mobile top padding from pt-24 to pt-6 since
  the desktop header is hidden on mobile (md:hidden)

https://claude.ai/code/session_01JYEwwgNbuCBoXMwYgagLfh

## Summary by Sourcery

Improve the mobile dashboard experience by making the orrery responsive and touch-interactive while adjusting layout spacing.

New Features:
- Enable touch-based drag controls for the BirthChartOrrery on mobile devices.

Bug Fixes:
- Prevent the orrery canvas and top padding from occupying the entire viewport on small mobile screens so dashboard content is visible above the fold.

Enhancements:
- Make the BirthChartOrrery canvas height responsive with smaller height on mobile and larger height on desktop.
- Simplify the BirthChartOrrery API by removing the unused configurable height prop.