### PR TITLE
fix(deploy): expand .railwayignore to exclude more large directories

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -2,8 +2,14 @@
 node_modules/
 .worktrees/
 media/
-features/plan/
+features/
 docs/
+bazodiac_engine/
+apps/
+packages/
+landing/
+plans/
+projekt_snapshot_outcome_der_erste_ankunftsmoment_.md
 
 # Build artifacts
 dist/


### PR DESCRIPTION
Reduces upload payload by excluding features/, bazodiac_engine/, apps/, packages/, landing/, plans/ — none needed for the production build.

## Summary by Sourcery

Deployment:
- Expand .railwayignore to skip large source and app directories that are not required for the production deployment build.