### PR TITLE
fix: resolve typecheck failures in quiz scoring and mobile dashboard

### DIFF
--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Alert, Pressable, ScrollView, Share, StyleSheet, Text, View } from "react-native";
+import type { DimensionValue } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useAppState } from "../contexts/AppStateContext";
@@ -106,7 +107,7 @@ export function DashboardScreen() {
           <Text style={styles.kicker}>WUXING 五行</Text>
           {wuxingElements.map(el => {
             const pct = Math.round((el.value / wuxingTotal) * 100);
-            const barWidth = `${(el.value / wuxingMax) * 100}%`;
+            const barWidth: DimensionValue = `${(el.value / wuxingMax) * 100}%`;
             return (
               <View key={el.key} style={styles.wuxingRow}>
                 <Text style={[styles.wuxingLabel, { color: el.color }]}>{el.chinese}</Text>

--- a/packages/shared/src/quizzes/scoring.ts
+++ b/packages/shared/src/quizzes/scoring.ts
@@ -18,6 +18,10 @@ export function scoreQuiz(
     case 'multi-dimension':
     case 'categorical':
       return scoreDimensional(quiz, answers);
+    default: {
+      const unknownModel: never = quiz.scoringModel;
+      throw new Error(`Unsupported scoring model: ${unknownModel}`);
+    }
   }
 }
 
@@ -25,6 +29,10 @@ function scoreProfileDriven(
   quiz: QuizDefinition,
   answers: Record<string, string>,
 ): QuizResult {
+  if (quiz.profiles.length === 0) {
+    throw new Error(`Quiz "${quiz.id}" has no profiles configured.`);
+  }
+
   const votes: Record<string, number> = {};
 
   for (const q of quiz.questions) {
@@ -59,6 +67,10 @@ function scoreDimensional(
   quiz: QuizDefinition,
   answers: Record<string, string>,
 ): QuizResult {
+  if (quiz.profiles.length === 0) {
+    throw new Error(`Quiz "${quiz.id}" has no profiles configured.`);
+  }
+
   const scores: Record<string, number> = {};
 
   for (const q of quiz.questions) {


### PR DESCRIPTION
### Motivation
- Fix TypeScript errors that caused CI `typecheck` to fail: a non-exhaustive `switch` in quiz scoring (TS2366) and an incompatible React Native style `width` type in the mobile dashboard (TS2322). 
- Add runtime guard rails to make quiz scoring fail fast on malformed quizzes and improve robustness.

### Description
- Make `scoreQuiz` exhaustive by adding a `default` branch that throws on unknown `scoringModel` values to ensure the function always returns or errors. 
- Add guards in `scoreProfileDriven` and `scoreDimensional` to throw when `quiz.profiles` is empty to prevent silent runtime misbehavior. 
- Fix mobile dashboard typing by importing `DimensionValue` and typing the computed Wuxing bar width as `DimensionValue` in `apps/mobile/src/screens/DashboardScreen.tsx`.

### Testing
- Ran `npm run typecheck` at the repo root which shows unrelated missing dependency errors in this environment and therefore could not fully validate the full workspace typecheck here. 
- Ran `npm run typecheck` inside `apps/mobile`, which failed to complete because `expo/tsconfig.base` could not be resolved and `npm install` in this environment failed with `403 Forbidden` when fetching registry packages, so a local end-to-end typecheck was not possible. 
- The specific CI-reported type errors (non-exhaustive `scoreQuiz` and `width` typing) were addressed in the code; automated typecheck runs could not be reproduced here due to dependency/registry access limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bada927f808322a7c99bf9359c9104)

## Summary by Sourcery

Resolve TypeScript typecheck failures in quiz scoring and the mobile dashboard while adding stronger runtime validation for quiz configuration.

Bug Fixes:
- Ensure quiz scoring handles all scoringModel variants by throwing on unsupported values instead of falling through.
- Prevent profile-based and dimensional quiz scoring from running when no profiles are configured, failing fast with a clear error.
- Align the mobile dashboard Wuxing bar width style with React Native's expected DimensionValue type to satisfy type checking.

Enhancements:
- Add explicit runtime guard rails in quiz scoring functions to catch malformed quiz definitions early.