### PR TITLE
refactor: centralize soulprint weight conversions via shared weight-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build-storybook": "storybook build",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit",
-    "typecheck:src": "bash ./scripts/ci-typecheck-src.sh",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/components/fusion-ring-3d/FusionRing3D.tsx
+++ b/src/components/fusion-ring-3d/FusionRing3D.tsx
@@ -9,7 +9,7 @@ import {
   type RingEffectType,
 } from '@/src/components/fusion-ring-website/FusionRingWebsiteCanvas';
 import FusionRingCanvasV2 from '@/src/components/fusion-ring-website/FusionRingCanvasV2';
-import { soulprintToNatalWeights, soulprintToDimensionWeights } from '@/src/components/fusion-ring-website/signatur-bridge';
+import { toDimensionWeightsOrUndefined, toNatalWeightsOrUndefined } from '@/src/lib/signatur/weight-utils';
 import { isFeatureEnabled } from '@/src/lib/feature-flags';
 import type { DissonanceResult } from '../../lib/fusion-ring/dissonance';
 import type { DayHarmonicState } from '../../lib/fusion-ring/day-harmonic';
@@ -87,12 +87,12 @@ export const FusionRing3D = ({
   const { kpIndex } = useSpaceWeather();
 
   const v2NatalWeights = useMemo(
-    () => signalData?.baseSignals ? soulprintToNatalWeights(signalData.baseSignals) : undefined,
+    () => toNatalWeightsOrUndefined(signalData?.baseSignals),
     [signalData?.baseSignals]
   );
 
   const v3DimensionWeights = useMemo(
-    () => signalData?.baseSignals ? soulprintToDimensionWeights(signalData.baseSignals) : undefined,
+    () => toDimensionWeightsOrUndefined(signalData?.baseSignals),
     [signalData?.baseSignals]
   );
 

--- a/src/components/onboarding/CosmicEncounter.tsx
+++ b/src/components/onboarding/CosmicEncounter.tsx
@@ -14,7 +14,7 @@ import { EncounterBirthForm } from './EncounterBirthForm';
 import { LeviSpeechBubble } from './LeviSpeechBubble';
 import { MyzeliumNetwork } from './MyzeliumNetwork';
 import { useParallax } from './useParallax';
-import { soulprintToNatalWeights } from '../fusion-ring-website/signatur-bridge';
+import { toNatalWeightsOrUndefined } from '@/src/lib/signatur/weight-utils';
 import type { BootstrapResponse, SignatureDeltaResponse } from '../../lib/schemas/experience';
 
 // Lazy-load heavy ring components
@@ -107,8 +107,7 @@ export function CosmicEncounter({
 
   // Compute natal weights when bootstrap data arrives
   const natalWeights = useMemo(() => {
-    if (!bootstrapData?.soulprint_sectors) return undefined;
-    return soulprintToNatalWeights(bootstrapData.soulprint_sectors);
+    return toNatalWeightsOrUndefined(bootstrapData?.soulprint_sectors);
   }, [bootstrapData]);
 
   // ── Phase 1: materializing → levi-speaks (3s auto-trigger) ────────

--- a/src/components/onboarding/SignatureReveal.tsx
+++ b/src/components/onboarding/SignatureReveal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import type { BootstrapResponse, SignatureDeltaResponse } from '@/src/lib/schemas/experience';
 import { isFeatureEnabled } from '@/src/lib/feature-flags';
-import { soulprintToNatalWeights, soulprintToDimensionWeights } from '@/src/components/fusion-ring-website/signatur-bridge';
+import { toDimensionWeightsOrUndefined, toNatalWeightsOrUndefined } from '@/src/lib/signatur/weight-utils';
 import { useLanguage } from '@/src/contexts/LanguageContext';
 
 const SignaturV3Canvas = lazy(() => import('@/src/components/signatur-v3/SignaturV3Canvas'));
@@ -38,9 +38,9 @@ export function SignatureReveal({ bootstrapData, onComplete, bootstrapFailed }: 
 
   const isFallback = bootstrapData.meta?.engine_version === 'fallback';
 
-  const natalWeights = useMemo(() => soulprintToNatalWeights(sectors), [sectors]);
-  const dimensionWeights = useMemo(() => soulprintToDimensionWeights(sectors), [sectors]);
-  const neutralDimensionWeights = useMemo(() => soulprintToDimensionWeights(DEFAULT_SECTORS), []);
+  const natalWeights = useMemo(() => toNatalWeightsOrUndefined(sectors), [sectors]);
+  const dimensionWeights = useMemo(() => toDimensionWeightsOrUndefined(sectors), [sectors]);
+  const neutralDimensionWeights = useMemo(() => toDimensionWeightsOrUndefined(DEFAULT_SECTORS) ?? {}, []);
 
   // Morph animation: neutral -> personal over 2s, then show button at 3s
   useEffect(() => {

--- a/src/pages/FuRingPage.tsx
+++ b/src/pages/FuRingPage.tsx
@@ -24,8 +24,7 @@ import {
   isClusterComplete,
   findClusterForModule,
 } from '@/src/lib/fusion-ring/clusters';
-import { quizSectorsToQuizWeights } from '@/src/components/fusion-ring-website/signatur-bridge';
-import { toNatalWeightsOrUndefined } from '@/src/lib/signatur/weight-utils';
+import { toNatalWeightsOrUndefined, toQuizWeightsOrUndefined } from '@/src/lib/signatur/weight-utils';
 import type { ContributionEvent } from '@/src/lib/lme/types';
 import { eventToSectorSignals } from '@/src/lib/fusion-ring/test-signal';
 import { useCoustoAudio } from '@/src/hooks/useCoustoAudio';
@@ -79,7 +78,7 @@ export default function FuRingPage() {
 
   // Cousto audio — dimension weights drive oscillator gains
   const audioWeights = useMemo(
-    () => liveQuizWeights ?? (signalData?.baseSignals ? quizSectorsToQuizWeights(signalData.baseSignals) : undefined),
+    () => liveQuizWeights ?? toQuizWeightsOrUndefined(signalData?.baseSignals),
     [liveQuizWeights, signalData?.baseSignals],
   );
   const { muted: audioMuted, toggleMute: toggleAudioMute, volume: audioVolume, setVolume: setAudioVolume } = useCoustoAudio(audioWeights);
@@ -121,7 +120,7 @@ export default function FuRingPage() {
       const sectors = eventToSectorSignals(event);
       if (sectors && sectors.length === 12) {
         const normalized = sectors.map(s => (s + 1) / 2);
-        setLiveQuizWeights(quizSectorsToQuizWeights(normalized));
+        setLiveQuizWeights(toQuizWeightsOrUndefined(normalized));
         setLiveQuizSectors(normalized);
       }
 


### PR DESCRIPTION
### Motivation
- Fix fragile import/transform drift that caused unresolved identifiers and TS2304 by standardizing where soulprint→weight conversions are invoked. 
- Provide a single guarded surface for 12-sector checks so runtime UI flows use the same guard semantics and reduce future regression risk.

### Description
- Replaced direct `signatur-bridge` conversion calls with guarded wrappers from `src/lib/signatur/weight-utils.ts` in `FusionRing3D`, `FuRingPage`, `CosmicEncounter`, and `SignatureReveal`. 
- Switched calls from `soulprintToNatalWeights`, `soulprintToDimensionWeights`, and `quizSectorsToQuizWeights` to `toNatalWeightsOrUndefined`, `toDimensionWeightsOrUndefined`, and `toQuizWeightsOrUndefined` respectively. 
- Added a safe fallback for the neutral V3 path (`neutralDimensionWeights`) in `SignatureReveal` to ensure V3 rendering is robust when conversions return `undefined`. 
- Removed a duplicated `typecheck:src` entry in `package.json` (script de-duplication). 

### Testing
- Ran `npm run typecheck:src` and it completed with `No TypeScript errors in src/` (success). 
- Ran `npx vitest run src/__tests__/signatur-weight-utils.test.ts` and the test file passed (`1 file, 3 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc4a16b1388322bc0ee20d475485c3)

## Summary by Sourcery

Centralize soulprint-to-weight conversions through shared guarded utilities to align UI flows and improve robustness.

Bug Fixes:
- Guard soulprint-to-weight conversions so components handle missing or invalid sector data without runtime or type errors.

Enhancements:
- Update FusionRing3D, FuRingPage, CosmicEncounter, and SignatureReveal to use shared weight utility wrappers instead of direct conversion calls.
- Provide a neutral fallback for Signatur V3 dimension weights when conversions return undefined.

Build:
- Remove a duplicated typecheck:src script entry from package.json.