### PR TITLE
fix: prevent GitHub Pages Jekyll UTF-8 and Liquid parsing failures

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,15 @@
+# GitHub Pages/Jekyll build configuration
+# Exclude binary files that were mistakenly committed with .md extension
+# to prevent UTF-8 parsing failures in Liquid/Jekyll.
+exclude:
+  - docs/Bazodiac_Dev_Brief_04_Cleanup.md
+  - features/docs/specs/Bazahuawa.md
+  - features/docs/specs/Bazodiac Fusion Ring Signal Logic.md
+  - features/docs/specs/Bazodiac_Semantic_Marker_Mapping_v2.md
+  - features/plan/Fu-Ring/Fu-Ring-final/Uploads/Dev_Brief_Fusion_Ring_v2.md
+  - features/plan/Implementation-plan/Bazodiac_Fusion_Ring_Architektur_v1.md
+  - features/plan/Implementation-plan/Bazodiac_Sky_Spec.md
+  - features/plan/Implementation-plan/Bazodiac_Transit_State_Spec.md
+  - features/plan/Implementation-plan/Dev_Brief_BaZi_Dashboard_v2.md
+  - features/plan/Implementation-plan/Dev_Brief_BaZi_WuXing_Dashboard.md
+  - features/plan/Implementation-plan/Dev_Brief_Fusion_Ring_v2.md

--- a/archive/DEV_BRIEF_COMPLETE_PORTIERUNG.md
+++ b/archive/DEV_BRIEF_COMPLETE_PORTIERUNG.md
@@ -94,8 +94,8 @@ Die einzig korrekte Version des neuen Onboardings, der Signatur und des Daily Ho
 + className?: string;
 
   // Im return JSX:
-- <div ref={canvasRef} style={{ width: '100%', height: '100%' }}>
-+ <div ref={canvasRef} className={className} style={{ width: '100%', height: '100%' }}>
+- <div ref={canvasRef} style={&#123;&#123; width: '100%', height: '100%' &#125;&#125;}>
++ <div ref={canvasRef} className={className} style={&#123;&#123; width: '100%', height: '100%' &#125;&#125;}>
 ```
 
 **Die bestehende `FusionRingWebsiteCanvas.tsx` (V1) NICHT löschen** — sie bleibt als Feature-Flag-Fallback.


### PR DESCRIPTION
### Motivation
- Jekyll builds were aborting with `invalid byte sequence in UTF-8` because several files with a `.md` extension actually contained binary/ZIP/DOCX payloads, and Liquid was also emitting warnings for unescaped JSX-style double-brace objects in an archive document.

### Description
- Add a new `_config.yml` that excludes the known binary `.md` files from GitHub Pages/Jekyll processing to avoid Liquid trying to parse non-UTF-8 content.
- Escape the JSX double-brace snippet in `archive/DEV_BRIEF_COMPLETE_PORTIERUNG.md` so Liquid no longer treats `{{ ... }}` as a template expression.
- Commit the two changes so Pages builds no longer attempt to parse the problematic files and the archive snippet renders without Liquid errors.

### Testing
- Ran a Python scan that detects `.md` files starting with ZIP header `PK\x03\x04`, and it successfully identified the files now listed under `exclude` in `_config.yml`.
- Ran ripgrep to confirm the `{{ width: '100%', height: '100%' }}` pattern is no longer present in `archive/DEV_BRIEF_COMPLETE_PORTIERUNG.md`, which succeeded.
- Verified the working tree and committed the intended changes with `git` which succeeded.
- Attempted to run `docker --version` to reproduce the GitHub Action container locally, but it failed because `docker` is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc7a42f42883228d04a909d527576b)

## Summary by Sourcery

Prevent GitHub Pages/Jekyll from attempting to parse binary markdown files and Liquid from interpreting JSX-style braces as templates.

Bug Fixes:
- Exclude known binary `.md` files from Jekyll processing via `_config.yml` to avoid UTF-8 parsing and Liquid failures.
- Escape a JSX-style double-brace style object in `archive/DEV_BRIEF_COMPLETE_PORTIERUNG.md` so Liquid no longer treats it as a template expression.