### PR TITLE
Harden LLM parsing + deterministic fallbacks for vibes/weekly/daily; align cooldown docs

### DIFF
--- a/4-deploy/runbooks/vibes-test.md
+++ b/4-deploy/runbooks/vibes-test.md
@@ -46,9 +46,9 @@ Manual test scenarios for the Day-Pulse "Vibe abrufen" feature covering generati
 
 1. Complete a vibe generation (scenario 2)
 2. Navigate away from Dashboard (e.g. `/signatur`) and return to `/`
-3. Tap "Vibe abrufen" again innerhalb des aktiven Cool-down-Fensters
-   - Free Tier: 4 Stunden
-   - Premium Tier: 2 Stunden
+3. Tap "Vibe abrufen" again within the active cooldown window
+   - Free Tier: 4 hours
+   - Premium Tier: 2 hours
 4. Verify result appears instantly (no loading skeleton, no network request)
 5. Output is identical to the first generation
 

--- a/4-deploy/runbooks/vibes-test.md
+++ b/4-deploy/runbooks/vibes-test.md
@@ -46,7 +46,9 @@ Manual test scenarios for the Day-Pulse "Vibe abrufen" feature covering generati
 
 1. Complete a vibe generation (scenario 2)
 2. Navigate away from Dashboard (e.g. `/signatur`) and return to `/`
-3. Tap "Vibe abrufen" again within 30 minutes
+3. Tap "Vibe abrufen" again innerhalb des aktiven Cool-down-Fensters
+   - Free Tier: 4 Stunden
+   - Premium Tier: 2 Stunden
 4. Verify result appears instantly (no loading skeleton, no network request)
 5. Output is identical to the first generation
 
@@ -76,8 +78,8 @@ Manual test scenarios for the Day-Pulse "Vibe abrufen" feature covering generati
 
 1. Complete a vibe generation and note the exact Kurzsignal text + Treiber pills
 2. Hard-refresh the page (Cmd+Shift+R)
-3. Tap "Vibe abrufen" again within the same 30-minute window
-4. Verify output is identical to the first run (same text, same pills, same order)
+3. Tap "Vibe abrufen" again within the same active cooldown window
+4. Verify output is identical to the first run (same text, same pills, same order) while still in cooldown
 
 ## Verification Checklist
 
@@ -88,9 +90,9 @@ Manual test scenarios for the Day-Pulse "Vibe abrufen" feature covering generati
 - [ ] Treiber shows 3-5 pill tags
 - [ ] "Warum sehe ich das?" expands/collapses explanation panel
 - [ ] Explanation references signatur + transit context
-- [ ] Cached result returns instantly on second tap within 30 min
+- [ ] Cached result returns instantly on second tap within active cooldown (Free: 4h, Premium: 2h)
 - [ ] Gemini block produces element-based fallback (no error)
 - [ ] Mobile 375px: content above fold, no horizontal overflow
 - [ ] No bare numbers or unexplained scores in output
-- [ ] Same user in same window produces identical output
+- [ ] Same user in same cooldown window produces identical output
 - [ ] No console errors (warnings acceptable)

--- a/server.mjs
+++ b/server.mjs
@@ -2291,8 +2291,13 @@ REGELN:
 
     if (!jsonStr) {
       console.error('[weekly] Empty response text from model, falling back');
-      const fallbackAreas = buildWeeklyFallbackAreas(areaScores);
-      return res.json({ week: isoWeek, areas: fallbackAreas, meta: { engine_version: 'v1-gemini-weekly', cached: false } });
+      const fallbackPayload = {
+        week: isoWeek,
+        areas: buildWeeklyFallbackAreas(areaScores),
+        meta: { engine_version: 'v1-gemini-weekly', cached: false },
+      };
+      weeklyCache.set(cacheKey, { data: fallbackPayload });
+      return res.status(200).json(fallbackPayload);
     }
 
     jsonStr = extractJsonPayload(jsonStr);

--- a/server.mjs
+++ b/server.mjs
@@ -1206,6 +1206,97 @@ function deterministicIndex(dateStr, sector, max) {
   return Math.abs(hash) % max;
 }
 
+function extractJsonPayload(raw) {
+  if (typeof raw !== 'string') return '';
+  let value = raw.trim();
+  if (!value) return '';
+  if (value.startsWith('```json')) {
+    value = value.replace(/^```json\s*/, '').replace(/\s*```$/, '');
+  }
+  if (!value.startsWith('{')) {
+    const first = value.indexOf('{');
+    const last = value.lastIndexOf('}');
+    if (first !== -1 && last !== -1 && last > first) {
+      value = value.slice(first, last + 1);
+    }
+  }
+  return value;
+}
+
+function buildWeeklyFallbackAreas(areaScores) {
+  return areaScores.map((area) => {
+    const tpl = WEEKLY_FALLBACK_TEMPLATES[area.key] || WEEKLY_FALLBACK_TEMPLATES.alltag;
+    return {
+      key: area.key,
+      label: area.label,
+      statement: tpl.statement,
+      tendency: tpl.tendency,
+      score: area.score,
+      rank: area.rank,
+      isHighlighted: area.isHighlighted,
+      explain: area.isHighlighted
+        ? tpl.explain
+        : 'Diese Tendenz entsteht aus der aktuellen Konstellation in Verbindung mit deiner persönlichen Struktur.',
+    };
+  });
+}
+
+function buildDailyFallbackPayload({ targetDate, lang, bafeData }) {
+  const german = lang !== 'en';
+  const dayMaster = bafeData?.bazi?.pillars?.day?.stem || '';
+  const sunSign = bafeData?.western?.zodiac_sign || (german ? 'dein Zeichen' : 'your sign');
+  const moonSign = bafeData?.western?.moon_sign || (german ? 'dein Mondzeichen' : 'your moon sign');
+  const harmonyIndex = 0.52;
+  const dayMode = harmonyIndex >= 0.5 ? 'trace' : 'pulse';
+  const synthesis = german
+    ? 'Heute entsteht Zug in deinem Alltag. Was innerlich klar ist, will sichtbar werden.'
+    : 'Today carries momentum. What is clear inside wants to become visible.';
+
+  return {
+    date: targetDate,
+    western: {
+      summary: german
+        ? `${sunSign} bringt heute Fokus auf klare Prioritäten.`
+        : `${sunSign} brings a focus on clear priorities today.`,
+      themes: german ? ['Ausrichtung', 'Klarheit'] : ['Alignment', 'Clarity'],
+      caution: german
+        ? 'Verteile deine Aufmerksamkeit nicht auf zu viele Baustellen.'
+        : 'Avoid splitting your attention across too many fronts.',
+      opportunity: german
+        ? 'Ein bewusst gesetzter Schritt kann heute viel tragen.'
+        : 'One deliberate step can carry a lot today.',
+      evidence: { transit_sectors: [1, 5] },
+    },
+    eastern: {
+      summary: german
+        ? `${moonSign} öffnet den Blick für feine Signale im Umfeld.`
+        : `${moonSign} opens your attention to subtle signals around you.`,
+      themes: german ? ['Wahrnehmung', 'Timing'] : ['Perception', 'Timing'],
+      caution: german
+        ? 'Handle nicht aus Druck, sondern aus innerer Ruhe.'
+        : 'Act from calm intent, not pressure.',
+      opportunity: german
+        ? 'Eine kleine Kurskorrektur verbessert den Tagesfluss deutlich.'
+        : 'A small course correction can improve the flow of your day.',
+      evidence: { day_master: dayMaster },
+    },
+    fusion: {
+      summary: german
+        ? 'Der Tag zeigt eine konkrete Tendenz mit gut nutzbarer Klarheit.'
+        : 'The day shows a concrete tendency with usable clarity.',
+      synthesis,
+      action: german
+        ? 'Entscheide heute eine Sache klar und setze sie direkt um.'
+        : 'Choose one thing clearly today and implement it directly.',
+      pushworthy: true,
+      push_text: german ? 'Heute ist ein guter Moment für einen klaren Schritt.' : 'Today is a good moment for one clear step.',
+      harmony_index: harmonyIndex,
+      day_mode: dayMode,
+    },
+    meta: { engine_version: 'v1-gemini-daily' },
+  };
+}
+
 app.get("/api/horoscope/daily/:userId", async (req, res) => {
   const userId = String(req.params.userId || "").trim();
   if (!userId) return res.status(400).json({ error: "Missing userId" });
@@ -1677,19 +1768,20 @@ NEVER use in synthesis: "weil", "da heute", planet names (Mars, Venus etc.), "di
           ? result.response.text
           : undefined;
     let jsonStr = rawText?.trim() || "";
+    let parsedData = null;
 
     if (!jsonStr) {
-      console.error("[experience/daily] Empty response text from model");
-      return res
-        .status(502)
-        .json({ error: "experience_unavailable", details: "empty_model_response" });
+      console.error("[experience/daily] Empty response text from model, using fallback payload");
+      parsedData = buildDailyFallbackPayload({ targetDate, lang, bafeData });
+    } else {
+      jsonStr = extractJsonPayload(jsonStr);
+      try {
+        parsedData = JSON.parse(jsonStr);
+      } catch (parseErr) {
+        console.warn('[experience/daily] Model JSON parse failed, using structured fallback:', parseErr?.message || parseErr);
+        parsedData = buildDailyFallbackPayload({ targetDate, lang, bafeData });
+      }
     }
-
-    if (jsonStr.startsWith('```json')) {
-      jsonStr = jsonStr.replace(/^```json\s*/, '').replace(/\s*```$/, '');
-    }
-    
-    const parsedData = JSON.parse(jsonStr);
 
     // Ensure harmony_index + day_mode are always present regardless of model output
     if (parsedData?.fusion) {
@@ -1970,11 +2062,28 @@ REGELN:
       });
     }
 
-    if (jsonStr.startsWith('```json')) {
-      jsonStr = jsonStr.replace(/^```json\s*/, '').replace(/\s*```$/, '');
+    jsonStr = extractJsonPayload(jsonStr);
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (parseErr) {
+      console.warn('[vibes] Model JSON parse failed, returning deterministic fallback:', parseErr?.message || parseErr);
+      const fb = VIBES_FALLBACK[dominantElement] || VIBES_FALLBACK.Fire;
+      const fallbackPayload = {
+        timestamp: new Date().toISOString(),
+        horizon: '2-3h',
+        kurzsignal: fb.kurzsignal,
+        treiber: fb.treiber,
+        erklaerung: fb.erklaerung,
+        explain: {
+          signatur_context: `Dominantes Element: ${dominantElement}`,
+          transit_context: spaceWeatherSummary,
+        },
+        meta: { engine_version: 'v1-gemini-vibes', cached: false },
+      };
+      vibesCache.set(cacheKey, { data: fallbackPayload, timestamp: Date.now() });
+      return res.status(200).json(fallbackPayload);
     }
-
-    const parsed = JSON.parse(jsonStr);
 
     // Assemble full payload with envelope
     const vibesPayload = {
@@ -2111,21 +2220,7 @@ app.post('/api/weekly-insights', requireUserAuth, async (req, res) => {
     // ── Gemini generation or fallback ────────────────────────────────
     if (!geminiClient) {
       console.warn('[weekly] Gemini API key missing, returning deterministic fallback');
-      const fallbackAreas = areaScores.map((area) => {
-        const tpl = WEEKLY_FALLBACK_TEMPLATES[area.key] || WEEKLY_FALLBACK_TEMPLATES.alltag;
-        return {
-          key: area.key,
-          label: area.label,
-          statement: tpl.statement,
-          tendency: tpl.tendency,
-          score: area.score,
-          rank: area.rank,
-          isHighlighted: area.isHighlighted,
-          explain: area.isHighlighted
-            ? tpl.explain
-            : 'Diese Tendenz entsteht aus der aktuellen Konstellation in Verbindung mit deiner persönlichen Struktur.',
-        };
-      });
+      const fallbackAreas = buildWeeklyFallbackAreas(areaScores);
       const fallbackPayload = {
         week: isoWeek,
         areas: fallbackAreas,
@@ -2196,22 +2291,24 @@ REGELN:
 
     if (!jsonStr) {
       console.error('[weekly] Empty response text from model, falling back');
-      const fallbackAreas = areaScores.map((area) => {
-        const tpl = WEEKLY_FALLBACK_TEMPLATES[area.key] || WEEKLY_FALLBACK_TEMPLATES.alltag;
-        return {
-          key: area.key, label: area.label, statement: tpl.statement, tendency: tpl.tendency,
-          score: area.score, rank: area.rank, isHighlighted: area.isHighlighted,
-          explain: area.isHighlighted ? tpl.explain : 'Diese Tendenz entsteht aus der aktuellen Konstellation in Verbindung mit deiner persönlichen Struktur.',
-        };
-      });
+      const fallbackAreas = buildWeeklyFallbackAreas(areaScores);
       return res.json({ week: isoWeek, areas: fallbackAreas, meta: { engine_version: 'v1-gemini-weekly', cached: false } });
     }
 
-    if (jsonStr.startsWith('```json')) {
-      jsonStr = jsonStr.replace(/^```json\s*/, '').replace(/\s*```$/, '');
+    jsonStr = extractJsonPayload(jsonStr);
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (parseErr) {
+      console.warn('[weekly] Model JSON parse failed, returning fallback:', parseErr?.message || parseErr);
+      const fallbackPayload = {
+        week: isoWeek,
+        areas: buildWeeklyFallbackAreas(areaScores),
+        meta: { engine_version: 'v1-gemini-weekly', cached: false },
+      };
+      weeklyCache.set(cacheKey, { data: fallbackPayload });
+      return res.status(200).json(fallbackPayload);
     }
-
-    const parsed = JSON.parse(jsonStr);
     const geminiAreas = Array.isArray(parsed.areas) ? parsed.areas : [];
 
     // Merge Gemini output with computed scores

--- a/server.mjs
+++ b/server.mjs
@@ -2314,7 +2314,17 @@ REGELN:
       weeklyCache.set(cacheKey, { data: fallbackPayload });
       return res.status(200).json(fallbackPayload);
     }
-    const geminiAreas = Array.isArray(parsed.areas) ? parsed.areas : [];
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !Array.isArray(parsed.areas)) {
+      console.warn('[weekly] Model JSON shape invalid, returning fallback');
+      const fallbackPayload = {
+        week: isoWeek,
+        areas: buildWeeklyFallbackAreas(areaScores),
+        meta: { engine_version: 'v1-gemini-weekly', cached: false },
+      };
+      weeklyCache.set(cacheKey, { data: fallbackPayload });
+      return res.status(200).json(fallbackPayload);
+    }
+    const geminiAreas = parsed.areas;
 
     // Merge Gemini output with computed scores
     const mergedAreas = areaScores.map((area) => {


### PR DESCRIPTION
### Motivation
- LLM responses sometimes contained non-strict JSON which caused `JSON.parse` to throw and left `/api/weekly-insights`, `/api/vibes` and `/api/experience/daily` unable to deliver useful payloads.
- The dashboard features (Vibe Check, Weekly Insights, Day Pulse/Trace) must always return a usable structure so UI components can render reliably even when the model output is malformed or empty.
- Runbook expectations for Vibes cooldown were out of sync with the server logic, creating QA drift.

### Description
- Added robust JSON extraction and parse-guard helper `extractJsonPayload` to normalize/groom model text before `JSON.parse` and avoid parse exceptions in `server.mjs`.
- Implemented deterministic fallbacks: `buildWeeklyFallbackAreas` for weekly insights and `buildDailyFallbackPayload` for daily horoscope, and integrated them so the server returns valid, displayable payloads when the model output is empty or invalid.
- Hardened `/api/vibes` parsing to return element-based deterministic fallback payloads and still populate L1/L2 caches when Gemini output is malformed.
- Replaced duplicated weekly fallback mapping with `buildWeeklyFallbackAreas` and updated the Vibes QA runbook (`4-deploy/runbooks/vibes-test.md`) to reflect the actual cooldown windows (Free: 4h, Premium: 2h).

### Testing
- Ran static type check with `npm run lint` and it completed successfully.
- Executed unit tests with `npm run test -- src/__tests__/day-mode-schema.test.ts src/__tests__/vibes-cooldown.test.ts src/__tests__/experience-schemas.test.ts` and all test files passed (3 files, 13 tests passed).
- Manual review of changed endpoints ensured they return structured fallback payloads when model responses are empty or malformed (behaviour exercised in tests and local server runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf26de866883228f583df146bc0965)

## Summary by Sourcery

Harden LLM-driven endpoints so daily horoscope, vibes, and weekly insights always return structured payloads by guarding JSON parsing and providing deterministic fallbacks, and align vibes cooldown documentation with server behavior.

New Features:
- Introduce a shared extractJsonPayload helper to sanitize and extract JSON snippets from model responses before parsing.
- Provide deterministic fallback payload builders for weekly insights areas and daily horoscope responses so clients receive usable data even when the model output is empty or invalid.

Bug Fixes:
- Prevent JSON.parse failures in daily experience, vibes, and weekly insights endpoints when the LLM returns code fences or malformed JSON by normalizing input and falling back to predefined payloads.
- Ensure vibes responses still populate cache and return an element-based fallback when Gemini output cannot be parsed.
- Align vibes cooldown QA runbook timings with the actual server cooldown behavior for free and premium tiers.

Enhancements:
- Deduplicate weekly fallback construction logic via a reusable buildWeeklyFallbackAreas helper.