### PR TITLE
Fix daily impact inclusion, prevent cached mutation, and user-scoped active-impact cache

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2253,6 +2253,7 @@ app.post('/api/experience/daily', requireUserAuth, async (req, res) => {
 
     const lang = locale?.startsWith('en') ? 'en' : 'de';
     const targetDate = target_date || new Date().toISOString().slice(0, 10);
+    const wantsImpact = Array.isArray(include) && include.includes('impact');
     const cacheKeyD = `daily:${userId}:${targetDate}:${lang}`;
 
     const now = new Date();
@@ -2265,6 +2266,60 @@ app.post('/api/experience/daily', requireUserAuth, async (req, res) => {
         soulprintSectors: soulprintSectors ?? null,
         lang,
       });
+    };
+
+    const clonePayload = (payload) => {
+      try {
+        return JSON.parse(JSON.stringify(payload));
+      } catch {
+        return payload && typeof payload === 'object' ? { ...payload } : payload;
+      }
+    };
+
+    let resolvedUserTier = req.userTier;
+    const resolveIsPremium = async () => {
+      if (resolvedUserTier === undefined && supabaseServer) {
+        try {
+          const { data: tierRow } = await supabaseServer
+            .from('profiles').select('tier').eq('id', userId).maybeSingle();
+          resolvedUserTier = tierRow?.tier ?? 'free';
+        } catch {
+          resolvedUserTier = 'free';
+        }
+      }
+      return resolvedUserTier === 'premium';
+    };
+
+    const appendImpactAndTierGates = async (responseData) => {
+      if (!wantsImpact) return;
+      try {
+        const impactData = await computeActiveImpactsCore(userId);
+        const impactForResponse = clonePayload(impactData);
+        responseData.impact = impactForResponse;
+
+        const isPremium = await resolveIsPremium();
+
+        if (responseData.fusion && !isPremium) {
+          responseData.fusion.action = lang === 'de'
+            ? 'Deine persönliche Tagesempfehlung ist Teil von Bazodiac Premium.'
+            : 'Your personal daily recommendation is part of Bazodiac Premium.';
+          responseData.fusion.action_locked = true;
+        }
+
+        if (!isPremium && responseData.impact) {
+          responseData.impact.resonance_badges = [];
+        }
+      } catch (impactErr) {
+        console.warn('[experience/daily] Impact computation failed, omitting impact block:', impactErr?.message);
+      }
+    };
+
+    const prepareDailyResponse = async (baseData) => {
+      const responseData = clonePayload(baseData) || {};
+      appendNightHarmony(responseData, now);
+      appendBadges(responseData, soulprintSectorsForBadge);
+      await appendImpactAndTierGates(responseData);
+      return responseData;
     };
 
     // Load soulprint sectors early — needed for badge computation in ALL paths
@@ -2285,9 +2340,8 @@ app.post('/api/experience/daily', requireUserAuth, async (req, res) => {
     if (horoscopeCache.has(cacheKeyD)) {
       const cached = horoscopeCache.get(cacheKeyD);
       if (Date.now() - cached.timestamp < HOROSCOPE_CACHE_TTL) {
-        appendNightHarmony(cached.data, now);
-        appendBadges(cached.data, soulprintSectorsForBadge);
-        return res.json(cached.data);
+        const responseData = await prepareDailyResponse(cached.data);
+        return res.json(responseData);
       }
     }
 
@@ -2303,10 +2357,9 @@ app.post('/api/experience/daily', requireUserAuth, async (req, res) => {
           .maybeSingle();
 
         if (dbCached?.payload_json) {
-          appendNightHarmony(dbCached.payload_json, now);
           horoscopeCache.set(cacheKeyD, { data: dbCached.payload_json, timestamp: Date.now() });
-          appendBadges(dbCached.payload_json, soulprintSectorsForBadge);
-          return res.json(dbCached.payload_json);
+          const responseData = await prepareDailyResponse(dbCached.payload_json);
+          return res.json(responseData);
         }
       } catch (e) {
         console.warn('[daily] L2 cache read failed, continuing to generation:', e.message);
@@ -2330,7 +2383,6 @@ app.post('/api/experience/daily', requireUserAuth, async (req, res) => {
         if (data.fusion.day_mode === undefined) {
           data.fusion.day_mode = data.fusion.harmony_index >= 0.50 ? 'trace' : 'pulse';
         }
-        appendNightHarmony(data, now);
       }
       if (resp.ok && supabaseServer) {
         // Persist to L2 (fire-and-forget)
@@ -2346,8 +2398,8 @@ app.post('/api/experience/daily', requireUserAuth, async (req, res) => {
           .then(({ error }) => { if (error) console.warn('[daily] DB cache upsert failed:', error.message); })
           .catch((e) => { console.warn('[daily] DB cache upsert threw:', e?.message || e); });
       }
-      appendBadges(data, soulprintSectorsForBadge);
-      return res.status(resp.status).json(data);
+      const responseData = await prepareDailyResponse(data);
+      return res.status(resp.status).json(responseData);
     }
 
     // Call BAFE for natal data to feed Gemini
@@ -2525,49 +2577,8 @@ NEVER use in synthesis: "weil", "da heute", planet names (Mars, Venus etc.), "di
         });
     }
 
-    // Append resonance badges (deterministic — always fresh, not cached)
-    appendBadges(parsedData, soulprintSectorsForBadge);
-
-    // ── v2: include=["impact"] merges ACTIVE_IMPACTS_v1 into response ───
-    const wantsImpact = Array.isArray(include) && include.includes('impact');
-    if (wantsImpact) {
-      try {
-        const impactData = await computeActiveImpactsCore(userId);
-        parsedData.impact = impactData;
-
-        // Determine user tier for premium gating (DEC-conversion-tiers).
-        // Deliberate: we query tier lazily here instead of using attachUserTier middleware
-        // on the route, because v1 callers (no include param) don't need tier at all —
-        // adding middleware would add a Supabase call to every daily request unnecessarily.
-        let userTier = req.userTier; // may already be set by middleware chain
-        if (userTier === undefined && supabaseServer) {
-          try {
-            const { data: tierRow } = await supabaseServer
-              .from('profiles').select('tier').eq('id', userId).maybeSingle();
-            userTier = tierRow?.tier ?? 'free';
-          } catch { userTier = 'free'; }
-        }
-        const isPremium = userTier === 'premium';
-
-        // Gate fusion.action — free users get teaser with upgrade CTA
-        if (parsedData.fusion && !isPremium) {
-          parsedData.fusion.action = lang === 'de'
-            ? 'Deine persönliche Tagesempfehlung ist Teil von Bazodiac Premium.'
-            : 'Your personal daily recommendation is part of Bazodiac Premium.';
-          parsedData.fusion.action_locked = true;
-        }
-
-        // Gate resonance_badges — free users see empty array when impact requested
-        if (!isPremium) {
-          parsedData.impact.resonance_badges = [];
-        }
-      } catch (impactErr) {
-        console.warn('[experience/daily] Impact computation failed, omitting impact block:', impactErr?.message);
-        // Don't fail the whole response — just omit the impact block
-      }
-    }
-
-    res.status(200).json(parsedData);
+    const responseData = await prepareDailyResponse(parsedData);
+    res.status(200).json(responseData);
   } catch (err) {
     console.error('[experience/daily] Error:', err.message);
     res.status(502).json({ error: 'experience_unavailable' });

--- a/src/hooks/useActiveImpacts.ts
+++ b/src/hooks/useActiveImpacts.ts
@@ -5,13 +5,14 @@
  * and resonance_badges[]. Operates independently of useDailyExperience() —
  * no shared request dependency.
  *
- * Caches in sessionStorage for 15 min keyed on UTC date (aligned with server cache).
+ * Caches in sessionStorage for 15 min keyed on UTC date + user id.
  *
  * Implements: REQ-F-active-planets-frontend
  */
 
 import { useEffect, useState } from 'react';
 import { authedFetch } from '@/src/lib/authedFetch';
+import { useAuth } from '@/src/contexts/AuthContext';
 import {
   ActiveImpactsSchema,
   type ActiveImpacts,
@@ -29,15 +30,15 @@ export interface ActiveImpactsState {
 
 const CACHE_TTL_MS = 15 * 60 * 1000;
 
-function cacheKey(): string {
+function cacheKey(userId: string): string {
   const now = new Date();
   const d = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
-  return `bazodiac_active_impacts:${d}`;
+  return `bazodiac_active_impacts:${userId}:${d}`;
 }
 
-function readCache(): ActiveImpacts | null {
+function readCache(userId: string): ActiveImpacts | null {
   try {
-    const raw = sessionStorage.getItem(cacheKey());
+    const raw = sessionStorage.getItem(cacheKey(userId));
     if (!raw) return null;
     const entry = JSON.parse(raw) as { data: ActiveImpacts; fetchedAt: number };
     if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) return null;
@@ -48,16 +49,18 @@ function readCache(): ActiveImpacts | null {
   }
 }
 
-function writeCache(data: ActiveImpacts): void {
+function writeCache(userId: string, data: ActiveImpacts): void {
   try {
-    sessionStorage.setItem(cacheKey(), JSON.stringify({ data, fetchedAt: Date.now() }));
+    sessionStorage.setItem(cacheKey(userId), JSON.stringify({ data, fetchedAt: Date.now() }));
   } catch {
     // sessionStorage unavailable or quota exceeded — skip silently
   }
 }
 
 export function useActiveImpacts(): ActiveImpactsState {
-  const cached = readCache();
+  const { user } = useAuth();
+  const userCacheId = user?.id ?? 'anonymous';
+  const cached = readCache(userCacheId);
   const [state, setState] = useState<ActiveImpactsState>({
     harmonyIndex: cached?.harmony_index ?? null,
     activePlanets: cached?.active_planets ?? [],
@@ -67,7 +70,25 @@ export function useActiveImpacts(): ActiveImpactsState {
   });
 
   useEffect(() => {
-    if (readCache() !== null) return;
+    const cachedForUser = readCache(userCacheId);
+    if (cachedForUser !== null) {
+      setState({
+        harmonyIndex: cachedForUser.harmony_index,
+        activePlanets: cachedForUser.active_planets,
+        resonanceBadges: cachedForUser.resonance_badges,
+        loading: false,
+        error: null,
+      });
+      return;
+    }
+
+    setState({
+      harmonyIndex: null,
+      activePlanets: [],
+      resonanceBadges: [],
+      loading: true,
+      error: null,
+    });
 
     let cancelled = false;
 
@@ -91,7 +112,7 @@ export function useActiveImpacts(): ActiveImpactsState {
           throw new Error('Impact response schema mismatch');
         }
 
-        writeCache(parsed.data);
+        writeCache(userCacheId, parsed.data);
 
         if (!cancelled) {
           setState({
@@ -115,7 +136,7 @@ export function useActiveImpacts(): ActiveImpactsState {
 
     void fetchImpacts();
     return () => { cancelled = true; };
-  }, []);
+  }, [userCacheId]);
 
   return state;
 }


### PR DESCRIPTION
### Motivation
- Ensure `include=["impact"]` produces a consistent v2-style response (with `impact` and free-tier gating) even when the daily payload is served from L1/L2 cache or the Gemini-proxy fallback. 
- Avoid accidentally mutating cached impact payloads and prevent client-side cross-user cache leakage when users sign out/sign in in the same browser session.

### Description
- Reworked `/api/experience/daily` response assembly in `server.mjs` to centralize per-request decoration into `prepareDailyResponse()` so `include=["impact"]` augmentation runs for L1 cache hits, L2 cache hits, Gemini-proxy fallback, and fresh generation (adds `prepareDailyResponse`, `appendImpactAndTierGates`, and `resolveIsPremium`).
- Prevent cached-object mutation by cloning payloads via `clonePayload()` and cloning the result of `computeActiveImpactsCore(userId)` before applying free-tier gating (`resonance_badges = []`).
- Updated cached-paths to call the shared preparation helper so `appendNightHarmony`, badge computation, and impact merging/gating are consistently applied to every response path.
- Scoped the client session cache in `src/hooks/useActiveImpacts.ts` to the authenticated user by including `user.id` in the `cacheKey()` and made the hook reset/refetch when `user` identity changes to avoid sharing cached impacts across accounts.

### Testing
- `npm run lint` (`tsc --noEmit`) completed successfully.
- `npm run test` was executed but the test run failed in this environment due to missing Supabase environment variables and unreachable local services (tests report missing `VITE_SUPABASE_*` and connection refused to ports `3000`/`3001`); these failures are environmental and pre-existing, not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de545937a08322b19f0f53740799bc)