### PR TITLE
[PR #264 follow-up] Fix /impact/active method in KohaerenzHero source-of-truth policy

### DIFF
--- a/docs/plans/KohaerenzHero-plan.md
+++ b/docs/plans/KohaerenzHero-plan.md
@@ -12,7 +12,7 @@ Normalize coherence/impact contracts to prevent frontend/backend divergence and 
 
 ## Source of truth policy
 
-1. Prefer `GET /api/impact/active` when calling through the app proxy; upstream route is `GET /impact/active`, for coherence hero and related impact modules.
+1. Prefer `POST /api/impact/active` when calling through the app proxy; upstream route is `POST /impact/active`, for coherence hero and related impact modules.
 2. Use `POST /api/experience/daily` only as fallback when calling through the app proxy; upstream fallback route is `POST /experience/daily`.
 3. When the primary source is present, disable secondary space-weather hooks for the same screen to avoid double-fetching and stale divergence.
 


### PR DESCRIPTION
### Motivation
- Correct a high-priority documentation bug where the KohaerenzHero plan referenced `GET /api/impact/active` and `GET /impact/active` even though the implemented and approved contract is `POST`, which would cause consumers to issue invalid requests and reintroduce frontend/backend divergence.

### Description
- Update `docs/plans/KohaerenzHero-plan.md` to prefer `POST /api/impact/active` (and `POST /impact/active` upstream) instead of `GET`, and commit the change to align the plan with the runtime contract.

### Testing
- Verified the change with `rg -n "GET /api/impact/active|GET /impact/active|POST /api/impact/active|POST /impact/active" docs/plans/KohaerenzHero-plan.md` and committed with `git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de586b1f848322b673e03dd9b8a69f)

## Summary by Sourcery

Documentation:
- Update the KohaerenzHero plan to document POST /api/impact/active (and POST /impact/active upstream) instead of GET for the impact source-of-truth endpoint.