### PR TITLE
Exclude internal `docs` and `.agents` from Jekyll build to prevent Liquid parse failures

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,5 @@ exclude:
   - features/plan/Implementation-plan/Dev_Brief_BaZi_Dashboard_v2.md
   - features/plan/Implementation-plan/Dev_Brief_BaZi_WuXing_Dashboard.md
   - features/plan/Implementation-plan/Dev_Brief_Fusion_Ring_v2.md
+  - docs
+  - .agents


### PR DESCRIPTION
### Motivation
- Jekyll/Liquid was parsing internal markdown under `docs/` and `.agents/` (which contain React/Framer snippets with `{{ ... }}`), causing Liquid syntax errors and hard build failures in the GitHub Pages/Jekyll CI.

### Description
- Add `docs` and `.agents` to the `_config.yml` `exclude` list so Jekyll will not attempt to parse these internal authoring folders.

### Testing
- Located occurrences of `{{ ... }}` with `rg` and inspected the failing file `docs/plans/2026-03-08-quiz-cluster-energy-system.md` to confirm the Liquid parsing root cause, verified `_config.yml` now contains `docs` and `.agents` using a Ruby YAML check, and attempted containerized and local Jekyll builds which could not be completed in this environment due to missing Docker and a repository `Gemfile`, respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de71d39aa8832297d166c31b07e13b)

## Summary by Sourcery

Build:
- Update Jekyll configuration to exclude the docs and .agents directories from the site build.