### PR TITLE
Fix: populate solar pressure for harmony index (follow-up to Feat/coherence first dashboard)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -347,6 +347,12 @@ const SPACE_WEATHER_CACHE_TTL_MS = 15 * 60 * 1000;
 
 let spaceWeatherCache = null;
 
+function deriveSolarPressureFromKp(kpLike) {
+  const kp = Number(kpLike);
+  if (!Number.isFinite(kp)) return 0;
+  return Math.max(0, Math.min(1, kp / 9));
+}
+
 // ── Proxy with fallback chain + cache + retry + timeout ──────────────
 async function proxyToBafeWithFallback(targetUrls, req, res) {
   const reqBody = req.method === "GET" ? undefined : req.body;
@@ -1880,7 +1886,7 @@ async function computeActiveImpactsCore(userId) {
   // 5. Compute harmony_index (0–100) — blends natal harmony with solar pressure
   const baseHarmony = profile.astro_json?.fusion?.harmony_index ?? 0.5;
   const sw = spaceWeatherCache?.payload;
-  const solarPressure = sw?.solar_pressure_score ?? 0;
+  const solarPressure = sw?.solar_pressure_score ?? deriveSolarPressureFromKp(sw?.kp_index ?? sw?.kp);
   const hWeight = Number(process.env.HARMONY_INDEX_HARMONY_WEIGHT) || 0.65;
   const sWeight = Number(process.env.HARMONY_INDEX_SOLAR_WEIGHT)   || 0.35;
   const harmonyIndex = Math.min(100, Math.max(0,
@@ -3445,6 +3451,7 @@ app.get("/api/space-weather", async (_req, res) => {
     console.warn("[space-weather] all sources failed — returning neutral Kp=0");
     return res.json({
       kp_index: 0,
+      solar_pressure_score: deriveSolarPressureFromKp(0),
       source: "fallback",
       fetched_at: new Date().toISOString(),
       cache_ttl_seconds: Math.round(SPACE_WEATHER_CACHE_TTL_MS / 1000),
@@ -3453,6 +3460,7 @@ app.get("/api/space-weather", async (_req, res) => {
 
   const payload = {
     ...result,
+    solar_pressure_score: deriveSolarPressureFromKp(result.kp_index ?? result.kp),
     fetched_at: new Date().toISOString(),
     cache_ttl_seconds: Math.round(SPACE_WEATHER_CACHE_TTL_MS / 1000),
   };

--- a/server.mjs
+++ b/server.mjs
@@ -1886,7 +1886,19 @@ async function computeActiveImpactsCore(userId) {
   // 5. Compute harmony_index (0–100) — blends natal harmony with solar pressure
   const baseHarmony = profile.astro_json?.fusion?.harmony_index ?? 0.5;
   const sw = spaceWeatherCache?.payload;
-  const solarPressure = sw?.solar_pressure_score ?? deriveSolarPressureFromKp(sw?.kp_index ?? sw?.kp);
+  const kpValue = sw?.kp_index ?? sw?.kp;
+  const hasSolarPressureScore = sw?.solar_pressure_score != null;
+  const hasKpValue = kpValue != null;
+  const solarPressure = hasSolarPressureScore
+    ? sw.solar_pressure_score
+    : hasKpValue
+      ? deriveSolarPressureFromKp(kpValue)
+      : 0;
+  const solarPressureSource = hasSolarPressureScore
+    ? (sw?.source ?? 'solar_pressure_score')
+    : hasKpValue
+      ? 'kp_derived'
+      : 'unavailable';
   const hWeight = Number(process.env.HARMONY_INDEX_HARMONY_WEIGHT) || 0.65;
   const sWeight = Number(process.env.HARMONY_INDEX_SOLAR_WEIGHT)   || 0.35;
   const harmonyIndex = Math.min(100, Math.max(0,


### PR DESCRIPTION
### Motivation
- The `harmony_index` calculation reads `spaceWeatherCache.payload.solar_pressure_score` but the live cache was only guaranteed to include Kp fields, causing `solarPressure` to remain `0` and bias the index away from live space-weather data.

### Description
- Added `deriveSolarPressureFromKp(kp)` in `server.mjs` to produce a normalized/clamped `solar_pressure_score` from a Kp value (`kp / 9` clamped to `0..1`).
- Updated the `/api/impact/active` calculation in `computeActiveImpactsCore` to use `sw?.solar_pressure_score ?? deriveSolarPressureFromKp(sw?.kp_index ?? sw?.kp)` so Kp-derived pressure is used when `solar_pressure_score` is missing.
- Ensured `/api/space-weather` responses always include `solar_pressure_score` by populating it on both the neutral fallback and the successful payload creation path so future cache entries are fully populated.

### Testing
- Ran a syntax/parse check with `node --check server.mjs`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df4b2dada083229ce63d9ed42f65f1)

## Summary by Sourcery

Populate solar pressure data for harmony index calculations using Kp-derived values and ensure space-weather responses always include a solar pressure score.

Bug Fixes:
- Prevent harmony index from defaulting to zero solar pressure when live space-weather data lacks an explicit solar_pressure_score field.

Enhancements:
- Derive a normalized solar pressure score from Kp values when solar_pressure_score is missing in space-weather data.
- Always include a computed solar_pressure_score in /api/space-weather responses, including neutral fallback payloads, so cache entries are fully populated.