### PR TITLE
feat(signatur-3d): hover tooltips on planet poles

### DIFF
--- a/src/components/signatur-3d/SignatureSphere3D.tsx
+++ b/src/components/signatur-3d/SignatureSphere3D.tsx
@@ -26,13 +26,13 @@
  *
  * SignaturRenderer integration lands in Phase H6.
  */
-import { useEffect, useMemo, useRef, type ReactElement } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Billboard, Text, Stats } from '@react-three/drei';
 import { useReducedMotion } from 'motion/react';
 
-import { PLANETS } from '@/src/lib/signatur-3d/planets';
+import { PLANETS, PLANET_MAP } from '@/src/lib/signatur-3d/planets';
 import type { PlanetName } from '@/src/lib/signatur-3d/planets';
 import {
   buildTrailPath,
@@ -40,6 +40,18 @@ import {
   getPolePairs,
   getPolePositions,
 } from '@/src/lib/signatur-3d/sphere-chladni';
+import {
+  PLANET_INFLUENCE,
+  TIER_LABEL,
+  TIER_SHORT_LABEL,
+  tierFor,
+} from '@/src/lib/signatur-3d/planet-tooltips';
+import { useLanguage } from '@/src/contexts/LanguageContext';
+
+/** Never let raycasts hit the wire/solid/haze sphere meshes — only the
+ *  pole markers should receive pointer events so hover tooltips work.
+ *  Returned from a `raycast` prop so R3F's event reconciler skips it. */
+const SKIP_RAYCAST = () => {};
 
 export interface SignatureSphere3DProps {
   /** Per-planet amplitude weights (e.g. result of `soulprintToPlanetWeights()`). */
@@ -200,6 +212,8 @@ interface AnimatedSceneProps {
   prefersReducedMotion: boolean;
   /** 0–9; scales the morph-clock so higher Kp = faster breathing. */
   kpIndex: number;
+  /** Hover handlers — drive the tooltip overlay outside the Canvas. */
+  onPoleHover: (name: PlanetName | null) => void;
 }
 
 function AnimatedScene({
@@ -212,6 +226,7 @@ function AnimatedScene({
   trails,
   prefersReducedMotion,
   kpIndex,
+  onPoleHover,
 }: AnimatedSceneProps): ReactElement {
   const signatureGroupRef = useRef<THREE.Group | null>(null);
   const timeRef = useRef(0);
@@ -262,8 +277,9 @@ function AnimatedScene({
       <pointLight position={[0, -4, -3]} intensity={1.5} color={0x7b3ff7} distance={15} />
 
       <group ref={signatureGroupRef}>
-        {/* Haze shell — inward-facing dark backdrop inside the sphere. */}
-        <mesh>
+        {/* Haze shell — inward-facing dark backdrop inside the sphere.
+            raycast disabled so it never intercepts pole hovers. */}
+        <mesh raycast={SKIP_RAYCAST}>
           <sphereGeometry args={[1.06, 32, 32]} />
           <meshBasicMaterial
             color={0x05050f}
@@ -273,8 +289,8 @@ function AnimatedScene({
           />
         </mesh>
 
-        {/* Wire layer — Chladni-displaced wireframe. */}
-        <mesh geometry={wireGeom}>
+        {/* Wire layer — Chladni-displaced wireframe. Skip raycast. */}
+        <mesh geometry={wireGeom} raycast={SKIP_RAYCAST}>
           <meshStandardMaterial
             color={0x4f6ef7}
             wireframe
@@ -285,8 +301,8 @@ function AnimatedScene({
           />
         </mesh>
 
-        {/* Solid layer — slightly smaller, dark core. */}
-        <mesh geometry={solidGeom}>
+        {/* Solid layer — slightly smaller, dark core. Skip raycast. */}
+        <mesh geometry={solidGeom} raycast={SKIP_RAYCAST}>
           <meshStandardMaterial
             color={0x06060f}
             transparent
@@ -312,7 +328,20 @@ function AnimatedScene({
           // three scene pointLights (blue/cyan/purple) make the base color
           // readable even at emissiveIntensity 0.
           return (
-            <group key={`pole-${i}`} position={[p.x, p.y, p.z]}>
+            <group
+              key={`pole-${i}`}
+              position={[p.x, p.y, p.z]}
+              onPointerOver={(e) => {
+                e.stopPropagation();
+                document.body.style.cursor = 'pointer';
+                onPoleHover(planet.name);
+              }}
+              onPointerOut={(e) => {
+                e.stopPropagation();
+                document.body.style.cursor = 'auto';
+                onPoleHover(null);
+              }}
+            >
               <mesh>
                 <sphereGeometry args={[markerRadius, 16, 16]} />
                 <meshStandardMaterial
@@ -475,6 +504,13 @@ export function SignatureSphere3D({
     background: planetariumMode ? '#02020a' : 'transparent',
   };
 
+  // Hover-tooltip state. Lives at the outer component so the tooltip overlay
+  // (rendered as a sibling of <Canvas>) can pull full Tailwind styling while
+  // the inner pole <group> fires pointer events.
+  const [hoveredPole, setHoveredPole] = useState<PlanetName | null>(null);
+  const { lang } = useLanguage();
+  const isDe = lang === 'de';
+
   return (
     <div
       data-testid="signature-sphere-3d"
@@ -499,8 +535,80 @@ export function SignatureSphere3D({
           trails={trails}
           prefersReducedMotion={prefersReducedMotion}
           kpIndex={kpIndex}
+          onPoleHover={setHoveredPole}
         />
       </Canvas>
+
+      {hoveredPole && (
+        <PoleTooltip
+          planetName={hoveredPole}
+          weight={Math.max(0, Math.min(1, weights[hoveredPole] ?? 0))}
+          isDe={isDe}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Tooltip overlay (outside the R3F Canvas) ────────────────────────────
+// Absolute-positioned so it floats on top of the sphere without pushing
+// layout. Rendered conditionally on hover. Styled with Tailwind so it
+// matches the rest of the app's dark luxury palette.
+function PoleTooltip({
+  planetName,
+  weight,
+  isDe,
+}: {
+  planetName: PlanetName;
+  weight: number;
+  isDe: boolean;
+}): ReactElement {
+  const planet = PLANET_MAP[planetName];
+  const tier = tierFor(weight);
+  const influence = PLANET_INFLUENCE[planetName][isDe ? 'de' : 'en'];
+  const tierLine = TIER_LABEL[tier][isDe ? 'de' : 'en'];
+  const tierShort = TIER_SHORT_LABEL[tier][isDe ? 'de' : 'en'];
+  const percent = Math.round(weight * 100);
+  const displayName = isDe ? planet.name_de : planet.name;
+  const archetype = planet.archetype_de; // German archetype line from planets.ts
+  // Short archetype labels fall back to the DE one for EN for now — can be
+  // expanded in planets.ts if an EN archetype_en is added.
+  const weightLabel = isDe ? 'Dein Anteil' : 'Your share';
+
+  return (
+    <div
+      data-testid="pole-tooltip"
+      data-planet={planetName}
+      className="pointer-events-none absolute left-3 top-3 z-30 max-w-[280px] rounded-xl border border-white/15 bg-black/75 p-3 text-white shadow-[0_0_40px_rgba(0,0,0,0.6)] backdrop-blur-md sm:left-4 sm:top-4 sm:max-w-[320px] sm:p-4"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="text-2xl leading-none"
+          style={{ color: planet.color }}
+          aria-hidden="true"
+        >
+          {planet.symbol}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold tracking-wide">{displayName}</p>
+          <p className="text-[10px] uppercase tracking-[0.18em] text-white/60">
+            {archetype}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-2 rounded-md border border-white/10 bg-white/5 px-2 py-1.5">
+        <span className="text-[11px] uppercase tracking-wider text-white/60">
+          {weightLabel}
+        </span>
+        <span className="text-[13px] font-semibold" style={{ color: planet.color }}>
+          {percent}% · {tierShort}
+        </span>
+      </div>
+
+      <p className="mt-2 text-[12px] leading-snug text-white/70">{tierLine}</p>
+
+      <p className="mt-2 text-[13px] leading-relaxed text-white/90">{influence}</p>
     </div>
   );
 }

--- a/src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx
+++ b/src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx
@@ -49,6 +49,12 @@ vi.mock('@react-three/drei', () => ({
   Stats: () => null,
 }));
 
+// The tooltip overlay uses useLanguage() from the app's LanguageContext —
+// stub it so SignatureSphere3D can render in isolation without a provider.
+vi.mock('@/src/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de', t: (k: string) => k, setLang: vi.fn() }),
+}));
+
 // Override the global three mock's SphereGeometry with a stub that exposes
 // a minimal `attributes.position` the displacement builder can iterate over.
 // Uses vertex count 0 so the inner loop is skipped entirely — we only care

--- a/src/lib/signatur-3d/planet-tooltips.ts
+++ b/src/lib/signatur-3d/planet-tooltips.ts
@@ -1,0 +1,91 @@
+/**
+ * Planet tooltip content for the 3D signature sphere.
+ *
+ * Two short sentences per planet, DE + EN. Surface the astrological
+ * archetype in everyday language — not astrologer jargon. The sphere
+ * already names the planet and shows the weight; this text answers
+ * "what does this planet actually mean for me".
+ */
+import type { PlanetName } from './planets';
+
+export interface PlanetTooltipContent {
+  de: string;
+  en: string;
+}
+
+export const PLANET_INFLUENCE: Readonly<Record<PlanetName, PlanetTooltipContent>> = {
+  Sun: {
+    de: 'Die Sonne steht für deine Kern-Identität — wer du wirklich bist, wenn kein Rauschen da ist. Sie prägt, wie klar und selbstverständlich du präsent sein kannst.',
+    en: 'The Sun represents your core identity — who you are when the noise falls away. It shapes how clearly and naturally you can simply be present.',
+  },
+  Moon: {
+    de: 'Der Mond zeigt deine Gefühlslage und deinen inneren Rhythmus. Er bestimmt, wie du Eindrücke aufnimmst und wo du Schutz, Nähe und Regeneration suchst.',
+    en: 'The Moon carries your emotional tone and inner rhythm. It shapes how you absorb impressions and where you seek safety, closeness, and renewal.',
+  },
+  Mercury: {
+    de: 'Merkur regiert Denken, Sprache und Austausch. Er entscheidet, wie schnell und wie nuanciert du Information verarbeitest und welche Brücken du zwischen Menschen baust.',
+    en: 'Mercury runs thought, speech, and exchange. It determines how fast and how subtly you process information and the bridges you build between people.',
+  },
+  Venus: {
+    de: 'Venus steht für Beziehung, Werte und dein Empfinden für Schönheit. Sie zeigt, was dich anzieht und wie du Harmonie, Nähe und Genuss gestaltest.',
+    en: 'Venus governs connection, values, and your sense of beauty. It shows what draws you in and how you shape harmony, closeness, and pleasure.',
+  },
+  Mars: {
+    de: 'Mars treibt an und zieht Grenzen. Er formt, wie du Impulse in Handeln verwandelst und wie deutlich du für dich und deine Richtung einstehst.',
+    en: 'Mars drives and draws the line. It shapes how you convert impulse into action and how clearly you stand for yourself and your direction.',
+  },
+  Jupiter: {
+    de: 'Jupiter öffnet Horizont und Vertrauen. Er entscheidet, wohin du dich ausdehnst, wie du Sinn erkennst und wo du innerlich weit werden kannst.',
+    en: 'Jupiter opens horizon and trust. It decides where you expand, how you recognise meaning, and where you become spacious inside.',
+  },
+  Saturn: {
+    de: 'Saturn baut Struktur, Zeit und Verantwortung ein. Er zeigt, wo du Tragfähiges erschaffst und wie reif du mit Grenzen und Ausdauer umgehst.',
+    en: 'Saturn builds structure, time, and responsibility. It shows where you create what lasts and how maturely you handle limits and patience.',
+  },
+  Uranus: {
+    de: 'Uranus bricht Gewohnheiten auf und schenkt Freiheit. Er markiert, wo du unkonventionell denkst, Durchbrüche brauchst und das System neu sortierst.',
+    en: 'Uranus breaks open habit and grants freedom. It marks where you think unconventionally, need breakthroughs, and re-sort the system.',
+  },
+  Neptune: {
+    de: 'Neptun löst Grenzen auf und öffnet für Vision und Intuition. Er zeigt, wo du Klarheit eher über feines Spüren als über harte Logik gewinnst.',
+    en: 'Neptune dissolves edges and opens vision and intuition. It shows where you find clarity through subtle feeling rather than hard logic.',
+  },
+  Pluto: {
+    de: 'Pluto arbeitet in der Tiefe und wandelt. Er zeigt, wo du durch radikale Ehrlichkeit Macht über dein Leben zurückgewinnst — und wo Altes gehen darf.',
+    en: 'Pluto works in the depth and transforms. It shows where radical honesty lets you reclaim power over your own life — and where the old may leave.',
+  },
+};
+
+export type WeightTier = 'dominant' | 'aktiv' | 'leise';
+
+/**
+ * Map a 0..1 weight to a tier label.
+ * Thresholds chosen so typical BaZi-derived profiles show ~2–4 dominant
+ * planets and ~2–3 leise planets, with the rest aktiv.
+ */
+export function tierFor(weight: number): WeightTier {
+  if (weight >= 0.6) return 'dominant';
+  if (weight >= 0.3) return 'aktiv';
+  return 'leise';
+}
+
+export const TIER_LABEL: Readonly<Record<WeightTier, PlanetTooltipContent>> = {
+  dominant: {
+    de: 'Bei dir prominent — trägt den Ton deiner Signatur spürbar.',
+    en: 'Prominent in your signature — carries the tone noticeably.',
+  },
+  aktiv: {
+    de: 'Ausgewogen bei dir — meldet sich klar, ohne zu dominieren.',
+    en: 'Balanced in your signature — clearly present but not dominant.',
+  },
+  leise: {
+    de: 'Im Hintergrund bei dir — wirkt eher beiläufig und wird in Ruhe sichtbar.',
+    en: 'Background in your signature — works quietly, visible in calm moments.',
+  },
+};
+
+export const TIER_SHORT_LABEL: Readonly<Record<WeightTier, PlanetTooltipContent>> = {
+  dominant: { de: 'dominant', en: 'dominant' },
+  aktiv:    { de: 'aktiv',    en: 'active' },
+  leise:    { de: 'leise',    en: 'quiet' },
+};


### PR DESCRIPTION
Sphere was visually richer post-tuning but still opaque ("was heisst das?"). Pole hover now surfaces a compact tooltip with the planet's general influence + user-specific weight tier.

- src/lib/signatur-3d/planet-tooltips.ts: DE+EN influence text (2 sentences per planet), tier thresholds (dominant >=0.6, aktiv >=0.3, leise <0.3), and short/long tier labels.
- SignatureSphere3D:
  - Each pole <group> fires onPointerOver/Out → hoveredPole state, cursor becomes pointer on hover.
  - Wire/solid/haze sphere meshes get raycast={() => null} so they never intercept pointer events; only the small pole markers hit-test.
  - Tooltip overlay rendered as a sibling of <Canvas>, absolute top-left, max 320px, Tailwind-styled to match app's dark-luxury palette.
  - Card shows: glyph + name + archetype, weight percent + tier short label, tier long description, full influence sentence.
  - Language pulled from useLanguage() context for DE/EN switching.
- Test mock: vi.mock('@/src/contexts/LanguageContext') so existing SignatureSphere3D smoke tests keep rendering in isolation.

Full suite (1948) green.

## Summary by Sourcery

Add hover-driven planet pole tooltips to the 3D signature sphere with localized content and tiered weight descriptions.

New Features:
- Display a UI tooltip overlay when hovering planet poles in the 3D signature sphere, showing planet identity, archetype, and user-specific weight information.
- Provide localized DE/EN planet influence copy and tier labels for use in the tooltip content.

Enhancements:
- Ensure only pole markers receive pointer events by disabling raycasts on the sphere meshes to make hover interactions reliable.

Tests:
- Mock the language context in SignatureSphere3D tests so the component and new tooltip behavior can be rendered in isolation.