### PR TITLE
fix(api): BAFE schema drift — array bodies + empty dominant_element + Wasser mapper

### DIFF
--- a/src/__tests__/bafe-schema-drift.test.ts
+++ b/src/__tests__/bafe-schema-drift.test.ts
@@ -1,0 +1,140 @@
+/**
+ * BAFE schema-drift regression test.
+ *
+ * Real prod response observed on 2026-04-21 (user ba719e2f-...) had:
+ *   - western.bodies as ARRAY of {name, sign_index, sign_name, longitude_deg, ...}
+ *   - wuxing.dominant_element = "" but wuxing.dominant_bazi = "Erde"
+ *   - western.ascendant_sign = "Gemini" (still works)
+ *
+ * The mapper must surface sun_sign + moon_sign from the array-shaped bodies
+ * and fill dominant_element from dominant_bazi/dominant_planet when
+ * dominant_element itself is empty. This test locks that contract so a
+ * future BAFE upgrade that reverts or changes the shape doesn't silently
+ * empty out the dashboard.
+ */
+import { describe, it, expect } from 'vitest';
+import { mapChartToApiResults } from '../services/api';
+import type { ChartResponse } from '../types/bafe';
+
+/** Minimal chart response mirroring the 2026-04-21 BAFE shape. */
+function buildNewShapeResponse(): ChartResponse {
+  return {
+    bazi: {
+      pillars: {
+        year:  { stamm: 'Ji', zweig: 'Mao', tier: 'Rabbit', element: 'Earth' },
+        month: { stamm: 'Bing', zweig: 'Chen', tier: 'Dragon', element: 'Fire' },
+        day:   { stamm: 'Ji', zweig: 'Wei', tier: 'Goat', element: 'Earth' },
+        hour:  { stamm: 'Xin', zweig: 'You', tier: 'Rooster', element: 'Metal' },
+      },
+      chinese: { day_master: 'Ji', year: { animal: 'Rabbit' } },
+    },
+    // New shape: array of body objects
+    bodies: [
+      { name: 'Sun',   sign_index: 10, sign_name: 'Aquarius',   longitude_deg: 303.75 },
+      { name: 'Moon',  sign_index: 6,  sign_name: 'Libra',      longitude_deg: 187.19 },
+      { name: 'Mercury', sign_index: 9, sign_name: 'Capricorn', longitude_deg: 291.45 },
+    ],
+    // Ascendant stays a degree value in angles.
+    angles: { Ascendant: 81.14, MC: 314.01, Vertex: 217.74 },
+    // dominant_element empty, but dominant_bazi populated.
+    wuxing: {
+      elements: { Wood: 6, Fire: 4, Earth: 6, Metal: 4.3, Water: 5.8 },
+      from_planets: { Holz: 4.9, Feuer: 3, Erde: 2, Metall: 1, Wasser: 4.3 },
+      from_bazi: { Holz: 1.1, Feuer: 1, Erde: 4, Metall: 3.3, Wasser: 1.5 },
+      dominant_bazi: 'Erde',
+      dominant_planet: 'Holz',
+      dominant_element: '',
+      harmony_index: 0.6211,
+    },
+    houses: {},
+    fusion: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/** Minimal chart response in the OLD shape (object keyed by body name). */
+function buildOldShapeResponse(): ChartResponse {
+  return {
+    bazi: {
+      pillars: {
+        year:  { stamm: 'Ji', zweig: 'Mao', tier: 'Rabbit', element: 'Earth' },
+        month: { stamm: 'Bing', zweig: 'Chen', tier: 'Dragon', element: 'Fire' },
+        day:   { stamm: 'Ji', zweig: 'Wei', tier: 'Goat', element: 'Earth' },
+        hour:  { stamm: 'Xin', zweig: 'You', tier: 'Rooster', element: 'Metal' },
+      },
+      chinese: { day_master: 'Ji', year: { animal: 'Rabbit' } },
+    },
+    // Old shape: dict keyed by body name
+    bodies: {
+      Sun:  { zodiac_sign: 0,  longitude: 15 },
+      Moon: { zodiac_sign: 3,  longitude: 95 },
+    } as unknown as never,
+    angles: { Ascendant: 120, MC: 200, Vertex: 270 },
+    wuxing: {
+      elements: { Wood: 1, Fire: 1, Earth: 1, Metal: 1, Water: 1 },
+      dominant_element: 'Fire',
+      harmony_index: 0.8,
+    },
+    houses: {},
+    fusion: { harmony_index: 0.75 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('mapChartToApiResults — BAFE schema drift', () => {
+  it('resolves sun/moon from new ARRAY-shaped bodies via sign_index', () => {
+    const mapped = mapChartToApiResults(buildNewShapeResponse());
+    expect(mapped.western.zodiac_sign).toBe('Aquarius');
+    expect(mapped.western.moon_sign).toBe('Libra');
+  });
+
+  it('resolves ascendant from angles.Ascendant degrees (new shape)', () => {
+    const mapped = mapChartToApiResults(buildNewShapeResponse());
+    // 81.14° → Gemini (60°..90°)
+    expect(mapped.western.ascendant_sign).toBe('Gemini');
+  });
+
+  it('fills dominant_element from dominant_bazi when BAFE leaves it empty', () => {
+    const mapped = mapChartToApiResults(buildNewShapeResponse());
+    // dominant_bazi "Erde" → normalised to English "Earth"
+    expect(mapped.wuxing.dominant_element).toBe('Earth');
+  });
+
+  it('keeps dominant_element as-is when BAFE supplies it directly', () => {
+    const mapped = mapChartToApiResults(buildOldShapeResponse());
+    expect(mapped.wuxing.dominant_element).toBe('Fire');
+  });
+
+  it('resolves sun/moon from old OBJECT-shaped bodies via zodiac_sign index', () => {
+    const mapped = mapChartToApiResults(buildOldShapeResponse());
+    expect(mapped.western.zodiac_sign).toBe('Aries');   // index 0
+    expect(mapped.western.moon_sign).toBe('Cancer');    // index 3
+  });
+
+  it('falls back to longitude_deg when sign_index is missing', () => {
+    const response = buildNewShapeResponse();
+    // Remove sign_index + sign_name, keep longitude_deg (which is 303.75 → Aquarius)
+    (response.bodies as unknown as Array<Record<string, unknown>>)[0] = {
+      name: 'Sun',
+      longitude_deg: 303.75,
+    };
+    const mapped = mapChartToApiResults(response);
+    expect(mapped.western.zodiac_sign).toBe('Aquarius');
+  });
+
+  it('returns undefined sun_sign when body entry is completely empty', () => {
+    const response = buildNewShapeResponse();
+    (response.bodies as unknown as Array<Record<string, unknown>>)[0] = { name: 'Sun' };
+    const mapped = mapChartToApiResults(response);
+    expect(mapped.western.zodiac_sign).toBeUndefined();
+  });
+
+  it('dominant_element falls back to dominant_planet when dominant_bazi is also empty', () => {
+    const response = buildNewShapeResponse();
+    const wx = response.wuxing as unknown as Record<string, unknown>;
+    wx.dominant_bazi = '';
+    wx.dominant_planet = 'Wasser';
+    const mapped = mapChartToApiResults(response);
+    expect(mapped.wuxing.dominant_element).toBe('Water');
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -493,7 +493,7 @@ export function mapChartToApiResults(raw: ChartResponse): Omit<ApiResults, 'issu
       Feuer:  src.Feuer  ?? src.Fire   ?? 0,
       Erde:   src.Erde   ?? src.Earth  ?? 0,
       Metall: src.Metall ?? src.Metal  ?? 0,
-      Wasser: vec.Wasser ?? vec.Water  ?? 0,
+      Wasser: src.Wasser ?? src.Water  ?? 0,
     },
     dominant_element: resolveDominantElement(raw.wuxing as Record<string, unknown>),
   };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -63,6 +63,83 @@ function signFromDegrees(deg: number | undefined | null): string | undefined {
   return SIGN_NAMES[Math.floor(((deg % 360) + 360) % 360 / 30)];
 }
 
+/**
+ * Normalise BAFE's `bodies` / `positions` shape into a dict keyed by body name.
+ *
+ * BAFE schema drift (observed 2026-04-21): the endpoint now returns an ARRAY
+ * of body objects — `[{name:"Sun", sign_index:10, sign_name:"Aquarius",
+ * longitude_deg:303.74, ...}, ...]` — where it used to return an OBJECT
+ * keyed by name (`{Sun: {zodiac_sign:10}, Moon: {...}}`). Older responses
+ * may still come through via cache, so we accept both shapes and always
+ * return the dict form that the rest of the mapper expects.
+ */
+function normalizeBodies(
+  bodies: unknown,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!bodies) return undefined;
+  if (Array.isArray(bodies)) {
+    const dict: Record<string, Record<string, unknown>> = {};
+    for (const body of bodies) {
+      if (!body || typeof body !== 'object') continue;
+      const name = (body as { name?: unknown }).name;
+      if (typeof name === 'string' && name.length > 0) {
+        dict[name] = body as Record<string, unknown>;
+      }
+    }
+    return dict;
+  }
+  if (typeof bodies === 'object') {
+    return bodies as Record<string, Record<string, unknown>>;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a zodiac sign from whichever BAFE body shape we received.
+ *
+ * Checks each known key in order and stops at the first readable value:
+ *   1. `sign_index`    (new BAFE, 0-based int 0..11)
+ *   2. `sign_name`     (new BAFE, English name — signFromIndex accepts it)
+ *   3. `zodiac_sign`   (old BAFE, number or name)
+ *   4. `sign`          (alt old shape)
+ *   5. `longitude_deg` (new BAFE, derive via signFromDegrees)
+ *   6. `longitude`     (alt old shape)
+ */
+function signFromBody(body: Record<string, unknown> | undefined): string | undefined {
+  if (!body) return undefined;
+  return (
+    signFromIndex(body.sign_index as number | string | undefined) ||
+    signFromIndex(body.sign_name as number | string | undefined) ||
+    signFromIndex(body.zodiac_sign as number | string | undefined) ||
+    signFromIndex(body.sign as number | string | undefined) ||
+    (body.longitude_deg != null ? signFromDegrees(body.longitude_deg as number) : undefined) ||
+    (body.longitude != null ? signFromDegrees(body.longitude as number) : undefined)
+  );
+}
+
+/**
+ * BAFE new schema emits `dominant_element: ""` for some chart responses
+ * while still populating `dominant_bazi` / `dominant_planet`. Pick the
+ * first non-empty signal and normalise German element names to English.
+ */
+function resolveDominantElement(wuxing: Record<string, unknown>): string {
+  const direct = wuxing.dominant_element;
+  if (typeof direct === 'string' && direct.length > 0) return direct;
+  const fallback =
+    (typeof wuxing.dominant_bazi === 'string' && wuxing.dominant_bazi) ||
+    (typeof wuxing.dominant_planet === 'string' && wuxing.dominant_planet) ||
+    '';
+  if (!fallback) return '';
+  const DE_TO_EN: Record<string, string> = {
+    Holz: 'Wood',
+    Feuer: 'Fire',
+    Erde: 'Earth',
+    Metall: 'Metal',
+    Wasser: 'Water',
+  };
+  return DE_TO_EN[fallback] ?? fallback;
+}
+
 const fetchWithTimeout = async (url: string, options: RequestInit, timeoutMs = 15000) => {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);
@@ -222,10 +299,12 @@ export async function calculateWestern(data: BirthData): Promise<MappedWestern> 
     nonexistentTime: "error",
   });
 
-  // BAFE returns zodiac_sign as 0-based index and ascendant as degrees.
-  // Dashboard expects English sign name strings.
-  const sunSign = signFromIndex(raw.bodies?.Sun?.zodiac_sign);
-  const moonSign = signFromIndex(raw.bodies?.Moon?.zodiac_sign);
+  // BAFE may return bodies as a dict keyed by name (old) or an array (new,
+  // observed 2026-04-21). Normalise and resolve via the shared helpers so
+  // sign_index / sign_name / longitude_deg all flow into English sign names.
+  const bodiesDict = normalizeBodies((raw as { bodies?: unknown }).bodies);
+  const sunSign = signFromBody(bodiesDict?.Sun);
+  const moonSign = signFromBody(bodiesDict?.Moon);
   const ascendantDeg = raw.angles?.Ascendant;
   const ascendantSign = signFromDegrees(ascendantDeg);
 
@@ -328,7 +407,9 @@ export function mapChartToApiResults(raw: ChartResponse): Omit<ApiResults, 'issu
   if (!raw.bazi?.pillars) {
     throw new Error('/chart response missing bazi.pillars');
   }
-  const bodiesSource = raw.positions || raw.bodies;
+  // Accept both old (object keyed by name) and new (array of body objects)
+  // BAFE shapes — see normalizeBodies for context.
+  const bodiesSource = normalizeBodies(raw.positions ?? raw.bodies);
   if (!bodiesSource) {
     throw new Error('/chart response missing positions/bodies');
   }
@@ -355,15 +436,16 @@ export function mapChartToApiResults(raw: ChartResponse): Omit<ApiResults, 'issu
     zodiac_sign: raw.bazi.chinese?.year?.animal || raw.bazi.pillars.year?.tier || '',
   };
 
-  const sunBody = bodiesSource?.Sun as Record<string, unknown> | undefined;
-  const moonBody = bodiesSource?.Moon as Record<string, unknown> | undefined;
-  const sunSign        = signFromIndex(sunBody?.zodiac_sign as number | string | undefined)
-                      || signFromIndex(sunBody?.sign as number | string | undefined)
-                      || (sunBody?.longitude != null ? signFromDegrees(sunBody.longitude as number) : undefined);
-  const moonSign       = signFromIndex(moonBody?.zodiac_sign as number | string | undefined)
-                      || signFromIndex(moonBody?.sign as number | string | undefined)
-                      || (moonBody?.longitude != null ? signFromDegrees(moonBody.longitude as number) : undefined);
-  const ascendantSign  = signFromDegrees(raw.angles?.Ascendant);
+  const sunSign       = signFromBody(bodiesSource.Sun);
+  const moonSign      = signFromBody(bodiesSource.Moon);
+  // Ascendant may arrive as a degree value (old shape) OR already a sign
+  // name (some new responses put `angles.Ascendant` as numeric, plus a
+  // separate `ascendant_sign` top-level string).
+  const ascendantSign =
+    signFromDegrees(raw.angles?.Ascendant) ??
+    signFromIndex(
+      (raw as { ascendant_sign?: unknown }).ascendant_sign as number | string | undefined,
+    );
 
   const normalizedHouses: Record<string, string> = {};
   if (raw.houses && typeof raw.houses === 'object') {
@@ -413,7 +495,7 @@ export function mapChartToApiResults(raw: ChartResponse): Omit<ApiResults, 'issu
       Metall: src.Metall ?? src.Metal  ?? 0,
       Wasser: vec.Wasser ?? vec.Water  ?? 0,
     },
-    dominant_element: raw.wuxing.dominant_element || '',
+    dominant_element: resolveDominantElement(raw.wuxing as Record<string, unknown>),
   };
 
   const fusion: BafeFusionResponse = raw.fusion || {};


### PR DESCRIPTION
## Summary
- Prod users after BAFE schema change (2026-04-21) saw empty Sonne/Mond/BaZi/Wu-Xing + "Keine Transit-Daten" — only Ascendant loaded.
- Root cause: BAFE `/chart` now returns `western.bodies` as **array** (`[{name:"Sun", sign_index:10, ...}]`); our mapper read `bodies?.Sun?.zodiac_sign` → `undefined` → columns persisted as NULL. Also `wuxing.dominant_element` empty while `dominant_bazi="Erde"` populated. Also `Wasser` key in elements map read from `vec` instead of `src` (copy-paste drift).

## Changes
- `src/services/api.ts`:
  - `normalizeBodies()` — accepts both array and dict shapes, always returns dict keyed by body name.
  - `signFromBody()` — priority chain `sign_index → sign_name → zodiac_sign → sign → longitude_deg → longitude`.
  - `resolveDominantElement()` — falls back to `dominant_bazi` / `dominant_planet`, normalises DE element names to EN.
  - `Wasser` key now reads from `src` (not `vec`) — aligns with 9 sibling keys, fixes the case where `wu_xing_vector` is empty and the `from_planets + from_bazi` fallback is used.
- `src/__tests__/bafe-schema-drift.test.ts` — 8 regression tests using the exact prod response shape observed today.

## Test plan
- [ ] `npm run typecheck:src` — clean
- [ ] `npx vitest run src/__tests__/bafe-schema-drift.test.ts` — 8/8 pass
- [ ] After merge + Railway deploy: fresh registration populates Sonne/Mond in Dashboard
- [ ] HALT-Gate: Gemini `GOOGLE_API_KEY` rotated on Railway (separate — daily horoscope 502 is a different issue)

## Follow-ups
- Backfill SQL for existing users with NULL `sun_sign`/`moon_sign` but populated `astro_json->'western'->'bodies'` (~60 users). Will ship as a one-shot SQL after merge + deploy.
- Structural fix (removing Superglue raw-BAFE write path) tracked in `docs/superglue-removal-stage-1-onboarding.md` — next major sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)