### PR TITLE
fix(api): bazi.zodiac_sign + day_master from new English-keyed pillars

### DIFF
--- a/src/__tests__/bafe-schema-drift.test.ts
+++ b/src/__tests__/bafe-schema-drift.test.ts
@@ -137,4 +137,43 @@ describe('mapChartToApiResults — BAFE schema drift', () => {
     const mapped = mapChartToApiResults(response);
     expect(mapped.wuxing.dominant_element).toBe('Water');
   });
+
+  it('bazi zodiac_sign resolves from new English-keyed pillar shape (no `chinese` block)', () => {
+    // Real 2026-04-22 BAFE bazi shape — `chinese` block is gone, pillars use
+    // English {stem, branch, animal, element} instead of old {stamm, zweig, tier}.
+    const response = {
+      bazi: {
+        pillars: {
+          year:  { stem: 'Ji',   branch: 'Si',  animal: 'Snake',   element: 'Erde' },
+          month: { stem: 'Bing', branch: 'Chen', animal: 'Dragon', element: 'Fire' },
+          day:   { stem: 'Ji',   branch: 'Wei',  animal: 'Goat',   element: 'Earth' },
+          hour:  { stem: 'Xin',  branch: 'You',  animal: 'Rooster', element: 'Metal' },
+        },
+      },
+      bodies: [
+        { name: 'Sun',  sign_index: 10, sign_name: 'Aquarius', longitude_deg: 303.75 },
+        { name: 'Moon', sign_index: 6,  sign_name: 'Libra',    longitude_deg: 187.19 },
+      ],
+      angles: { Ascendant: 81.14 },
+      wuxing: {
+        elements: { Wood: 1, Fire: 1, Earth: 1, Metal: 1, Water: 1 },
+        dominant_element: 'Earth',
+      },
+      houses: {},
+      fusion: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const mapped = mapChartToApiResults(response);
+    expect(mapped.bazi.zodiac_sign).toBe('Snake');
+    expect(mapped.bazi.day_master).toBe('Ji');
+  });
+
+  it('bazi prefers direct zodiac_sign / day_master top-level fields when BAFE supplies them', () => {
+    const response = buildNewShapeResponse();
+    (response.bazi as unknown as Record<string, unknown>).zodiac_sign = 'Tiger';
+    (response.bazi as unknown as Record<string, unknown>).day_master = 'Gui';
+    const mapped = mapChartToApiResults(response);
+    expect(mapped.bazi.zodiac_sign).toBe('Tiger');
+    expect(mapped.bazi.day_master).toBe('Gui');
+  });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -432,8 +432,22 @@ export function mapChartToApiResults(raw: ChartResponse): Omit<ApiResults, 'issu
       day:   mapPillar(raw.bazi.pillars.day),
       hour:  mapPillar(raw.bazi.pillars.hour),
     },
-    day_master: raw.bazi.chinese?.day_master || raw.bazi.pillars.day?.stamm || (raw.bazi.pillars.day as unknown as { stem?: string })?.stem || '',
-    zodiac_sign: raw.bazi.chinese?.year?.animal || raw.bazi.pillars.year?.tier || '',
+    // BAFE new shape (2026-04-22): `raw.bazi.chinese` no longer exists and
+    // pillars use English keys ({stem, branch, animal, element}) instead of
+    // the old German ({stamm, zweig, tier, element}). Fallback chain accepts
+    // both so the mapper degrades to whichever shape is on the wire.
+    day_master:
+      (raw.bazi as { day_master?: string }).day_master ||
+      raw.bazi.chinese?.day_master ||
+      raw.bazi.pillars.day?.stamm ||
+      (raw.bazi.pillars.day as unknown as { stem?: string })?.stem ||
+      '',
+    zodiac_sign:
+      (raw.bazi as { zodiac_sign?: string }).zodiac_sign ||
+      raw.bazi.chinese?.year?.animal ||
+      (raw.bazi.pillars.year as unknown as { animal?: string })?.animal ||
+      raw.bazi.pillars.year?.tier ||
+      '',
   };
 
   const sunSign       = signFromBody(bodiesSource.Sun);


### PR DESCRIPTION
## Summary
Third BAFE schema drift observed on prod 2026-04-22 (user `d7c60715`): `bazi` block dropped `chinese` wrapper entirely, pillars switched from German keys (`stamm/zweig/tier`) to English (`stem/branch/animal`). Our mapper already handled pillars, but `zodiac_sign` + `day_master` only checked the deprecated `chinese.*` paths and German `tier` fallback — both returned `''` → Dashboard showed `—` in the BaZi identity pill.

## Supabase diagnosis
```sql
astro_json->'bazi'->'pillars'->'year' = {"stem":"Ji","animal":"Snake","branch":"Si","element":"Erde"}
astro_json->'bazi'->'chinese' = null          -- wrapper gone
astro_json->'bazi'->'zodiac_sign' = null      -- mapper output empty
```

## Changes
- `src/services/api.ts` — extend `zodiac_sign` + `day_master` fallback chains to accept (a) direct top-level `bazi.zodiac_sign` / `bazi.day_master`, (b) new English `pillars.year.animal` / `pillars.day.stem` keys, (c) old German keys as final fallback.
- `src/__tests__/bafe-schema-drift.test.ts` — 2 regression cases: new English-pillar shape (`zodiac_sign="Snake"`), direct top-level fields take priority over pillar extraction. 10/10 tests pass.

## Test plan
- [x] `npm run typecheck:src` — clean
- [x] `npx vitest run src/__tests__/bafe-schema-drift.test.ts` — 10/10 pass
- [ ] Merge + Railway deploy → fresh registration shows real BaZi animal in Dashboard

## Follow-ups
- Same root cause as #296 (BAFE schema drift). The structural fix is the Superglue-removal sprint — once BAFE responses flow through our mapper on the server side, these drift patches stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)