### PR TITLE
feat(server): OpenRouter free-tier fallback chain for Gemini quota exhaustion

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -7,7 +7,7 @@ import { createClient } from "@supabase/supabase-js";
 import compression from "compression";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
-import { GoogleGenAI } from "@google/genai";
+import { createGenAiRouter } from "./server/ai-router.mjs";
 import Stripe from 'stripe';
 
 // Exponential-backoff fetch helper used by the bootstrap endpoint.
@@ -178,7 +178,7 @@ if (missing.length > 0) {
   console.warn(`[server] WARNING: Missing env vars (dev mode): ${missing.join(', ')}`);
 }
 
-const OPTIONAL_ENV_VARS = ['GEMINI_API_KEY', 'ELEVENLABS_TOOL_SECRET', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'STRIPE_BUY_ID', 'SUPERGLUE_API_KEY'];
+const OPTIONAL_ENV_VARS = ['GEMINI_API_KEY', 'OPENROUTER_API_KEY', 'ELEVENLABS_TOOL_SECRET', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'STRIPE_BUY_ID', 'SUPERGLUE_API_KEY'];
 for (const v of OPTIONAL_ENV_VARS) {
   if (!process.env[v]) {
     console.warn(`[server] Optional env var not set: ${v} (some features may be degraded)`);
@@ -186,9 +186,15 @@ for (const v of OPTIONAL_ENV_VARS) {
 }
 
 // ── Gemini client (server-side only — key never reaches browser) ──────
-const geminiClient = process.env.GEMINI_API_KEY
-  ? new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY })
-  : null;
+// Wrapped in a transparent fallback router: primary calls go to Gemini
+// direct, then on 429/quota errors roll through OpenRouter free-tier
+// models (each has its own rate-limit bucket). Call-sites use the same
+// `.models.generateContent({...})` + `.getGenerativeModel({...})` surfaces
+// they used before, so no changes needed downstream.
+const geminiClient = createGenAiRouter({
+  geminiApiKey: process.env.GEMINI_API_KEY,
+  openrouterApiKey: process.env.OPENROUTER_API_KEY,
+});
 
 // ── Stripe client (server-side only) ──────────────────────────────
 const stripe = process.env.STRIPE_SECRET_KEY

--- a/server/ai-router.mjs
+++ b/server/ai-router.mjs
@@ -98,8 +98,12 @@ function geminiContentsToMessages(contents, systemInstruction) {
  */
 function normalizeOpenRouterModel(requestedModel, fallbackModel) {
   if (!requestedModel) return fallbackModel;
-  // If caller passed an OpenRouter slug directly, respect it.
-  if (requestedModel.includes('/')) return requestedModel;
+  // If caller passed an OpenRouter slug directly, only let it override the
+  // matching chain entry. Otherwise we collapse the entire fallback chain
+  // into repeated attempts against the same model.
+  if (requestedModel.includes('/')) {
+    return requestedModel === fallbackModel ? requestedModel : fallbackModel;
+  }
   return fallbackModel;
 }
 

--- a/server/ai-router.mjs
+++ b/server/ai-router.mjs
@@ -1,0 +1,240 @@
+/**
+ * AI provider fallback router.
+ *
+ * Wraps `@google/genai` with a transparent fallback chain to OpenRouter
+ * free-tier models so a Gemini-direct quota exhaustion (429
+ * RESOURCE_EXHAUSTED) no longer bubbles up as a 502 at the edge.
+ *
+ * Priority order:
+ *   1. Gemini direct       — GEMINI_API_KEY (highest fidelity + lowest latency)
+ *   2. OpenRouter free     — OPENROUTER_API_KEY × FREE_MODEL_CHAIN
+ *                            (each model has its own quota, so the chain
+ *                            effectively multiplies free capacity)
+ *
+ * Surface mirrors `@google/genai` closely:
+ *   - `.models.generateContent({ model, contents, config })` → `{ text, response: { text } }`
+ *   - `.getGenerativeModel({ model }).generateContent(prompt)` → `{ response: { text(): string } }`
+ *
+ * Non-quota errors (malformed request, auth failure, network) short-circuit
+ * and throw — we only fall through on 429-like signals so latency stays
+ * predictable for genuine bugs.
+ */
+
+import { GoogleGenAI } from '@google/genai';
+
+/**
+ * OpenRouter free-tier models, ordered by preference. Each has its own
+ * rate-limit bucket, so the chain effectively multiplies free capacity.
+ * Keep Gemini-compatible models first (similar prompt/JSON behaviour) and
+ * diverse providers afterwards as emergency fallback.
+ */
+export const DEFAULT_FREE_MODEL_CHAIN = Object.freeze([
+  'google/gemini-2.0-flash-exp:free',
+  'google/gemini-flash-1.5:free',
+  'meta-llama/llama-3.3-70b-instruct:free',
+  'qwen/qwen-2.5-72b-instruct:free',
+]);
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const OPENROUTER_TIMEOUT_MS = 30_000;
+
+/**
+ * Detect quota / rate-limit failures. Only these trigger fallback — any
+ * other error (401 bad key, 400 bad request, network drop) is bubbled so
+ * the caller can log it without the fallback masking the real cause.
+ */
+function isQuotaOr429Error(err) {
+  if (!err) return false;
+  const status = err.status ?? err.statusCode ?? err?.error?.code;
+  if (status === 429) return true;
+  const msg = String(err?.message || err || '').toLowerCase();
+  return /429|resource_exhausted|quota|rate.?limit|exceeded your current quota/.test(msg);
+}
+
+/**
+ * Convert a Gemini `contents` payload (string | array of turns) into OpenAI
+ * chat-completion `messages`. `systemInstruction` from the Gemini config
+ * becomes a system-role message prepended to the chain.
+ */
+function geminiContentsToMessages(contents, systemInstruction) {
+  const messages = [];
+  if (systemInstruction) {
+    const sysText =
+      typeof systemInstruction === 'string'
+        ? systemInstruction
+        : Array.isArray(systemInstruction?.parts)
+          ? systemInstruction.parts.map((p) => p?.text ?? '').join('')
+          : '';
+    if (sysText) messages.push({ role: 'system', content: sysText });
+  }
+
+  if (contents == null) return messages;
+  if (typeof contents === 'string') {
+    messages.push({ role: 'user', content: contents });
+    return messages;
+  }
+  if (Array.isArray(contents)) {
+    for (const turn of contents) {
+      if (typeof turn === 'string') {
+        messages.push({ role: 'user', content: turn });
+        continue;
+      }
+      if (!turn || typeof turn !== 'object') continue;
+      const role = turn.role === 'model' || turn.role === 'assistant' ? 'assistant' : 'user';
+      const text = Array.isArray(turn.parts)
+        ? turn.parts.map((p) => (typeof p === 'string' ? p : (p?.text ?? ''))).join('')
+        : (turn.text || '');
+      if (text) messages.push({ role, content: text });
+    }
+    return messages;
+  }
+  return messages;
+}
+
+/**
+ * Map a Gemini model id to whatever OpenRouter exposes for a closely
+ * matching capability. We don't need an exhaustive map — the fallback
+ * chain itself rotates through known-good free models.
+ */
+function normalizeOpenRouterModel(requestedModel, fallbackModel) {
+  if (!requestedModel) return fallbackModel;
+  // If caller passed an OpenRouter slug directly, respect it.
+  if (requestedModel.includes('/')) return requestedModel;
+  return fallbackModel;
+}
+
+/**
+ * Single OpenRouter call. Throws on any non-2xx response; the router above
+ * decides whether to fall through based on {@link isQuotaOr429Error}.
+ */
+async function callOpenRouter({ apiKey, model, request, referer, title }) {
+  const systemInstruction = request?.config?.systemInstruction;
+  const messages = geminiContentsToMessages(request?.contents, systemInstruction);
+  const wantsJson = request?.config?.responseMimeType === 'application/json';
+
+  const body = {
+    model,
+    messages,
+  };
+  if (request?.config?.temperature != null) body.temperature = request.config.temperature;
+  if (request?.config?.maxOutputTokens != null) body.max_tokens = request.config.maxOutputTokens;
+  if (wantsJson) body.response_format = { type: 'json_object' };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPENROUTER_TIMEOUT_MS);
+  try {
+    const res = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        // Recommended by OpenRouter so requests show up in the dashboard.
+        ...(referer ? { 'HTTP-Referer': referer } : {}),
+        ...(title ? { 'X-Title': title } : {}),
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) {
+      const raw = await res.text().catch(() => '');
+      const err = new Error(`openrouter ${model} ${res.status}: ${raw.slice(0, 300)}`);
+      err.status = res.status;
+      throw err;
+    }
+    const data = await res.json();
+    const text = data?.choices?.[0]?.message?.content ?? '';
+    return { text, response: { text }, _source: `openrouter:${model}`, raw: data };
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+/**
+ * Factory. Returns an object that mirrors the subset of `@google/genai`
+ * used by server.mjs. Falsy inputs (no direct key AND no openrouter key)
+ * return `null` so the existing `if (!geminiClient)` guards at every
+ * call-site keep working.
+ */
+export function createGenAiRouter({
+  geminiApiKey,
+  openrouterApiKey,
+  freeModelChain = DEFAULT_FREE_MODEL_CHAIN,
+  referer = 'https://astro-noctum-production.up.railway.app',
+  title = 'Bazodiac',
+} = {}) {
+  const hasGemini = typeof geminiApiKey === 'string' && geminiApiKey.length > 0;
+  const hasOpenRouter = typeof openrouterApiKey === 'string' && openrouterApiKey.length > 0;
+  if (!hasGemini && !hasOpenRouter) return null;
+
+  const direct = hasGemini ? new GoogleGenAI({ apiKey: geminiApiKey }) : null;
+  const chain = Array.isArray(freeModelChain) && freeModelChain.length > 0 ? freeModelChain : DEFAULT_FREE_MODEL_CHAIN;
+
+  async function generateContent(request) {
+    const attempts = [];
+    if (direct) {
+      attempts.push({
+        label: 'gemini-direct',
+        call: () => direct.models.generateContent(request),
+      });
+    }
+    if (hasOpenRouter) {
+      for (const model of chain) {
+        const resolved = normalizeOpenRouterModel(request?.model, model);
+        attempts.push({
+          label: `openrouter:${resolved}`,
+          call: () => callOpenRouter({ apiKey: openrouterApiKey, model: resolved, request, referer, title }),
+        });
+      }
+    }
+    let lastErr = null;
+    for (let i = 0; i < attempts.length; i++) {
+      const { label, call } = attempts[i];
+      try {
+        const result = await call();
+        if (i > 0) {
+          console.warn(`[ai-router] recovered via ${label} after ${i} failed attempt(s)`);
+        }
+        return result;
+      } catch (err) {
+        lastErr = err;
+        if (!isQuotaOr429Error(err)) {
+          // Non-quota error — surface it rather than wasting the rest of the chain.
+          throw err;
+        }
+        console.warn(`[ai-router] ${label} quota/429, falling through`);
+      }
+    }
+    throw lastErr ?? new Error('[ai-router] all providers exhausted');
+  }
+
+  return {
+    /** New-API surface used by most call-sites. */
+    models: { generateContent },
+    /**
+     * Legacy surface used by `/api/analyze/conversation` — returns a
+     * pseudo-model whose `.generateContent(prompt)` returns `{ response: { text() } }`.
+     * Caller at server.mjs L5912 uses `result.response.text()` as a FUNCTION.
+     */
+    getGenerativeModel({ model }) {
+      return {
+        generateContent: async (promptOrRequest) => {
+          const request =
+            typeof promptOrRequest === 'string'
+              ? { model, contents: promptOrRequest }
+              : { model, ...promptOrRequest };
+          const result = await generateContent(request);
+          const text = typeof result?.text === 'string' ? result.text : '';
+          return {
+            text,
+            response: {
+              text: () => text,
+            },
+            _source: result?._source,
+          };
+        },
+      };
+    },
+  };
+}

--- a/src/__tests__/ai-router.test.ts
+++ b/src/__tests__/ai-router.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Fallback-chain behaviour for server/ai-router.mjs.
+ *
+ * Covers:
+ *   - Primary Gemini call succeeds → return directly, no fetch to OpenRouter.
+ *   - Gemini throws 429/quota → rolls through OpenRouter free models.
+ *   - First OpenRouter model 429 → rolls to the next in the chain.
+ *   - Non-quota errors short-circuit (don't mask real bugs).
+ *   - `getGenerativeModel(...).generateContent(prompt)` surface still returns
+ *     a `{ response: { text() } }` shape for the legacy caller in server.mjs.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGenerateContent = vi.fn();
+vi.mock('@google/genai', () => ({
+  // Class form so `new GoogleGenAI({...})` works at runtime.
+  GoogleGenAI: class {
+    models = { generateContent: mockGenerateContent };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    constructor(_config: any) {}
+  },
+}));
+
+// Import AFTER the mock is registered.
+// Using a dynamic import so the default export is re-evaluated fresh per test
+// (not strictly necessary with vi.mock, but keeps the test easy to reason about).
+import { createGenAiRouter, DEFAULT_FREE_MODEL_CHAIN } from '../../server/ai-router.mjs';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchOnce(responseOverrides: Array<{ ok?: boolean; status?: number; body?: unknown; text?: string }>) {
+  const impls = responseOverrides.map((r) => () => {
+    return Promise.resolve({
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: () => Promise.resolve(r.body ?? { choices: [{ message: { content: r.text ?? 'ok' } }] }),
+      text: () => Promise.resolve(r.text ?? JSON.stringify(r.body ?? {})),
+    } as unknown as Response);
+  });
+  const fn = vi.fn(() => {
+    const next = impls.shift();
+    if (!next) throw new Error('fetch called more times than expected');
+    return next();
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('createGenAiRouter — fallback chain', () => {
+  beforeEach(() => {
+    mockGenerateContent.mockReset();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns null when neither GEMINI nor OPENROUTER key is set', () => {
+    const router = createGenAiRouter({ geminiApiKey: undefined, openrouterApiKey: undefined });
+    expect(router).toBeNull();
+  });
+
+  it('uses Gemini direct on success — never hits OpenRouter', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    mockGenerateContent.mockResolvedValueOnce({ text: 'direct' });
+
+    const router = createGenAiRouter({ geminiApiKey: 'g', openrouterApiKey: 'o' })!;
+    const out = await router.models.generateContent({
+      model: 'gemini-2.0-flash',
+      contents: 'hi',
+      config: { temperature: 0.7 },
+    });
+
+    expect(out.text).toBe('direct');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to OpenRouter when Gemini throws 429 quota error', async () => {
+    mockGenerateContent.mockRejectedValueOnce(
+      new Error('[GoogleGenerativeAI Error]: 429 RESOURCE_EXHAUSTED Quota exceeded'),
+    );
+    const fetchMock = mockFetchOnce([{ text: 'from-openrouter' }]);
+
+    const router = createGenAiRouter({
+      geminiApiKey: 'g',
+      openrouterApiKey: 'o',
+      freeModelChain: ['google/gemini-2.0-flash-exp:free'],
+    })!;
+    const out = await router.models.generateContent({
+      model: 'gemini-2.0-flash',
+      contents: 'hi',
+    });
+
+    expect(out.text).toBe('from-openrouter');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.model).toBe('google/gemini-2.0-flash-exp:free');
+    expect(body.messages).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
+  it('rolls through multiple OpenRouter models when each returns 429', async () => {
+    mockGenerateContent.mockRejectedValueOnce(
+      new Error('429 RESOURCE_EXHAUSTED'),
+    );
+    const fetchMock = mockFetchOnce([
+      { ok: false, status: 429, text: '{"error":"rate limit"}' },
+      { ok: false, status: 429, text: '{"error":"rate limit"}' },
+      { text: 'third-wins' },
+    ]);
+
+    const router = createGenAiRouter({
+      geminiApiKey: 'g',
+      openrouterApiKey: 'o',
+      freeModelChain: ['first:free', 'second:free', 'third:free'],
+    })!;
+    const out = await router.models.generateContent({ model: 'x', contents: 'q' });
+    expect(out.text).toBe('third-wins');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('short-circuits on non-quota errors from Gemini (400 bad request)', async () => {
+    mockGenerateContent.mockRejectedValueOnce(
+      Object.assign(new Error('400 INVALID_ARGUMENT bad request'), { status: 400 }),
+    );
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const router = createGenAiRouter({ geminiApiKey: 'g', openrouterApiKey: 'o' })!;
+    await expect(
+      router.models.generateContent({ model: 'x', contents: 'hi' }),
+    ).rejects.toThrow(/400|INVALID_ARGUMENT/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards responseMimeType=application/json as response_format for OpenRouter', async () => {
+    mockGenerateContent.mockRejectedValueOnce(new Error('429 quota'));
+    const fetchMock = mockFetchOnce([{ body: { choices: [{ message: { content: '{"k":1}' } }] } }]);
+
+    const router = createGenAiRouter({
+      geminiApiKey: 'g',
+      openrouterApiKey: 'o',
+      freeModelChain: ['only:free'],
+    })!;
+    await router.models.generateContent({
+      model: 'x',
+      contents: 'give json',
+      config: { responseMimeType: 'application/json', temperature: 0.2, maxOutputTokens: 512 },
+    });
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(body.response_format).toEqual({ type: 'json_object' });
+    expect(body.temperature).toBe(0.2);
+    expect(body.max_tokens).toBe(512);
+  });
+
+  it('legacy getGenerativeModel().generateContent(prompt) returns response.text() as a function', async () => {
+    mockGenerateContent.mockResolvedValueOnce({ text: 'legacy-style' });
+    const router = createGenAiRouter({ geminiApiKey: 'g', openrouterApiKey: undefined })!;
+    const model = router.getGenerativeModel({ model: 'gemini-2.0-flash' });
+    const result = await model.generateContent('analyse this');
+    expect(typeof result.response.text).toBe('function');
+    expect(result.response.text()).toBe('legacy-style');
+  });
+
+  it('preserves OpenRouter default chain when no override is passed', () => {
+    expect(DEFAULT_FREE_MODEL_CHAIN.length).toBeGreaterThan(0);
+    expect(DEFAULT_FREE_MODEL_CHAIN.every((m) => m.includes(':free'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Direct Gemini key is on the free tier and hits `429 RESOURCE_EXHAUSTED` almost immediately after deploy (`limit: 0` for generate_content_free_tier_requests). `/api/experience/daily` then bubbles 502 and the Dashboard flashes a brief error screen before falling back to local placeholders — the error Ben observed post-registration on 2026-04-22.

Fix: transparent multi-provider router wrapping the existing Gemini client. Primary call still hits Gemini direct (lowest latency, highest fidelity). On 429 / quota / rate-limit signals, rolls through a chain of OpenRouter free-tier models — each has its own rate-limit bucket, so the chain effectively multiplies free capacity:

1. `google/gemini-2.0-flash-exp:free`
2. `google/gemini-flash-1.5:free`
3. `meta-llama/llama-3.3-70b-instruct:free`
4. `qwen/qwen-2.5-72b-instruct:free`

Non-quota errors (`400 INVALID_ARGUMENT`, `401 auth`, network) short-circuit immediately rather than consume the chain for genuine bugs.

## Changes
- **`server/ai-router.mjs` (new)** — `createGenAiRouter({geminiApiKey, openrouterApiKey, freeModelChain?})` mirrors the subset of `@google/genai` the rest of server.mjs already uses:
  - `.models.generateContent({model, contents, config})` → `{text, response: {text}}`
  - `.getGenerativeModel({model}).generateContent(prompt)` → `{response: {text()}}`
  - Seven call-sites in server.mjs keep working verbatim — no changes downstream.
- **`server.mjs`** — `GoogleGenAI` import replaced with `createGenAiRouter`; `OPENROUTER_API_KEY` added to `OPTIONAL_ENV_VARS`.
- **`src/__tests__/ai-router.test.ts`** — 8 vitest cases:
  - happy-path Gemini direct, never hits OpenRouter
  - 429 fallthrough → OpenRouter model 1
  - multi-model rolling when each model returns 429
  - non-quota error short-circuit (doesn't waste chain on 400/auth)
  - JSON mode (`responseMimeType:"application/json"`) → `response_format:{type:"json_object"}`
  - legacy `getGenerativeModel(...).generateContent(prompt)` returns `response.text()` as a function
  - null-safety when neither key is set
  - default-chain invariants

## Test plan
- [x] `npm run typecheck:src` — clean
- [x] `npx vitest run src/__tests__/ai-router.test.ts` — 8/8 pass
- [x] `npx vitest run` — 1965/1966 pass (one pre-existing `vibes-perf.test.ts` failure, unrelated)
- [ ] After merge + Railway deploy: register fresh user, verify no error flash + daily horoscope renders (either from Gemini direct if quota resets overnight, or from OpenRouter if not)
- [ ] Railway log filter `[ai-router]` shows fallback recovery messages under quota pressure

## Railway env
`OPENROUTER_API_KEY` set via MCP (deploy skipped — will apply on next deploy from this PR's merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)