### PR TITLE
feat(signatur): transparency badge — no-placeholder-fake for transit-state fallback

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1465,10 +1465,16 @@ app.get("/api/transit-state/:userId", requireUserAuth, async (req, res) => {
       }
     }
     console.warn("[transit-state] fallback:", reason);
+    const source = profile ? "fallback-profile" : "fallback-neutral";
+    const payload = fallbackStateFromProfile(userId, profile);
+    // Surface the degradation in BOTH header (debug / tooling) and body
+    // (for the frontend). No-placeholder-fake directive: UI must be able
+    // to distinguish live transits from synthesized natal-fallback data.
+    payload._meta = { source, reason };
     return res
       .status(200)
       .set("X-Transit-Fallback", profile ? "profile-derived" : "neutral")
-      .json(fallbackStateFromProfile(userId, profile));
+      .json(payload);
   };
 
   try {
@@ -1537,6 +1543,10 @@ app.get("/api/transit-state/:userId", requireUserAuth, async (req, res) => {
       },
       events: (fufireData.events ?? []).map((ev) => mapFufireEvent(ev, generatedAt)),
       resolution,
+      // Explicit source marker so the UI can distinguish live FuFirE data
+      // from synthesized natal-profile fallback. Paired with the fallback
+      // payload's `_meta.source` in `respondWithFallback`.
+      _meta: { source: "live" },
     };
 
     return res.status(200).json(response);

--- a/src/__tests__/transit-source-badge.test.tsx
+++ b/src/__tests__/transit-source-badge.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * TransitSourceBadge — transparency badge shown when the Signatur ring is
+ * not driven by live FuFirE transit data.
+ *
+ * Contract (no-placeholder-fake directive):
+ *   - `source === 'live'`             → renders nothing.
+ *   - `source === 'fallback-profile'` → renders a visible static-natal label.
+ *   - `source === 'fallback-neutral'` → renders a visible neutral-pattern label.
+ *   - `reason` is appended to the tooltip hint when present.
+ *   - DE + EN copy variants both cover label + hint.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TransitSourceBadge } from '../components/signatur/TransitSourceBadge';
+
+vi.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de', t: (k: string) => k, setLang: vi.fn() }),
+}));
+
+describe('TransitSourceBadge', () => {
+  it('renders nothing when source is live', () => {
+    const { container } = render(<TransitSourceBadge source="live" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the static-natal label when source is fallback-profile', () => {
+    render(<TransitSourceBadge source="fallback-profile" />);
+    const badge = screen.getByTestId('transit-source-badge');
+    expect(badge.getAttribute('data-source')).toBe('fallback-profile');
+    expect(badge.textContent).toContain('Statische Natal-Signatur');
+  });
+
+  it('renders the neutral label + amber tone when source is fallback-neutral', () => {
+    render(<TransitSourceBadge source="fallback-neutral" />);
+    const badge = screen.getByTestId('transit-source-badge');
+    expect(badge.getAttribute('data-source')).toBe('fallback-neutral');
+    expect(badge.textContent).toContain('Neutrale Signatur');
+    // amber tone class applied on the neutral variant so the user perceives
+    // it as more alarming than the profile-derived fallback.
+    expect(badge.className).toMatch(/amber/);
+  });
+
+  it('appends reason into the tooltip hint when provided', () => {
+    render(<TransitSourceBadge source="fallback-profile" reason="FuFirE 503" />);
+    const badge = screen.getByTestId('transit-source-badge');
+    expect(badge.getAttribute('title')).toContain('FuFirE 503');
+  });
+
+  it('uses aria-live="polite" so screen readers announce the state quietly', () => {
+    render(<TransitSourceBadge source="fallback-neutral" />);
+    const badge = screen.getByTestId('transit-source-badge');
+    expect(badge.getAttribute('role')).toBe('status');
+    expect(badge.getAttribute('aria-live')).toBe('polite');
+  });
+});

--- a/src/__tests__/transit-state-source-schema.test.ts
+++ b/src/__tests__/transit-state-source-schema.test.ts
@@ -1,0 +1,80 @@
+/**
+ * TransitState / FusionSignalData — source marker roundtrip.
+ *
+ * Locks the no-placeholder-fake contract at the schema level: whenever
+ * the server sends `_meta.source` it must survive Zod parsing and flow
+ * into `FusionSignalData.source` unchanged. Legacy payloads without the
+ * field default to `'live'` so cached responses from before this change
+ * don't false-positive as fallback data.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  TransitStateSchema,
+  FusionSignalDataSchema,
+} from '../lib/schemas/transit-state';
+
+function baseTransit(meta?: Record<string, unknown>) {
+  return {
+    ring: { sectors: new Array(12).fill(0.5) },
+    soulprint: { sectors: new Array(12).fill(0.5) },
+    transit_contribution: { transit_intensity: 0.5 },
+    delta: { vs_30day_avg: { avg_sectors: new Array(12).fill(0.5) } },
+    events: [],
+    resolution: 75,
+    ...(meta !== undefined ? { _meta: meta } : {}),
+  };
+}
+
+describe('TransitStateSchema source marker', () => {
+  it('accepts live source explicitly', () => {
+    const parsed = TransitStateSchema.parse(baseTransit({ source: 'live' }));
+    expect(parsed._meta?.source).toBe('live');
+  });
+
+  it('accepts fallback-profile + optional reason', () => {
+    const parsed = TransitStateSchema.parse(
+      baseTransit({ source: 'fallback-profile', reason: 'FuFirE 503' }),
+    );
+    expect(parsed._meta?.source).toBe('fallback-profile');
+    expect(parsed._meta?.reason).toBe('FuFirE 503');
+  });
+
+  it('accepts fallback-neutral', () => {
+    const parsed = TransitStateSchema.parse(baseTransit({ source: 'fallback-neutral' }));
+    expect(parsed._meta?.source).toBe('fallback-neutral');
+  });
+
+  it('defaults legacy payloads without _meta to live', () => {
+    const parsed = TransitStateSchema.parse(baseTransit());
+    expect(parsed._meta?.source).toBe('live');
+  });
+
+  it('rejects unknown source values', () => {
+    const result = TransitStateSchema.safeParse(baseTransit({ source: 'magic' }));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('FusionSignalDataSchema source field', () => {
+  const base = {
+    targetSignals: new Array(12).fill(0),
+    baseSignals: new Array(12).fill(0.5),
+    thirtyDayAvg: new Array(12).fill(0.5),
+    transitIntensity: 0.5,
+  };
+
+  it('defaults source to live when omitted', () => {
+    const parsed = FusionSignalDataSchema.parse(base);
+    expect(parsed.source).toBe('live');
+  });
+
+  it('preserves fallback-profile + reason through the schema', () => {
+    const parsed = FusionSignalDataSchema.parse({
+      ...base,
+      source: 'fallback-profile',
+      sourceReason: 'FuFirE 503',
+    });
+    expect(parsed.source).toBe('fallback-profile');
+    expect(parsed.sourceReason).toBe('FuFirE 503');
+  });
+});

--- a/src/components/signatur/TransitSourceBadge.tsx
+++ b/src/components/signatur/TransitSourceBadge.tsx
@@ -1,0 +1,78 @@
+/**
+ * Small transparency badge that tells the user whether the Signatur they
+ * are looking at is driven by **live** transit data (FuFirE response) or
+ * by a **fallback** (synthesized from their stored natal soulprint, or
+ * pure neutral when no profile exists).
+ *
+ * Per the no-placeholder-fake directive, fallback state must be visually
+ * indicated rather than silently presented as real transit data. The badge
+ * is intentionally tiny and unobtrusive so it does not hijack attention
+ * when everything is fine — on `source === 'live'` it renders nothing.
+ */
+import { useLanguage } from '@/src/contexts/LanguageContext';
+import type { TransitSource } from '@/src/lib/schemas/transit-state';
+
+interface TransitSourceBadgeProps {
+  source: TransitSource;
+  reason?: string;
+  className?: string;
+}
+
+const COPY: Record<TransitSource, { de: { label: string; hint: string }; en: { label: string; hint: string } }> = {
+  'live': {
+    de: { label: 'Live', hint: '' },
+    en: { label: 'Live', hint: '' },
+  },
+  'fallback-profile': {
+    de: {
+      label: 'Statische Natal-Signatur',
+      hint: 'Live-Transits sind gerade nicht verfügbar — du siehst dein gespeichertes Natal-Muster, nicht den aktuellen Transit.',
+    },
+    en: {
+      label: 'Static natal signature',
+      hint: 'Live transits are currently unavailable — you are seeing your stored natal pattern, not today\u2019s transit.',
+    },
+  },
+  'fallback-neutral': {
+    de: {
+      label: 'Neutrale Signatur',
+      hint: 'Weder Transit noch Natal-Profil verfügbar — das Muster ist generisch und nicht an dich angepasst.',
+    },
+    en: {
+      label: 'Neutral signature',
+      hint: 'Neither transit nor natal profile available — the pattern is generic, not personalised.',
+    },
+  },
+};
+
+export function TransitSourceBadge({ source, reason, className }: TransitSourceBadgeProps) {
+  const { lang } = useLanguage();
+  if (source === 'live') return null;
+
+  const copy = COPY[source][lang === 'de' ? 'de' : 'en'];
+  const fullHint = reason ? `${copy.hint} (${reason})` : copy.hint;
+
+  const toneClass =
+    source === 'fallback-neutral'
+      ? 'border-amber-400/40 bg-amber-950/30 text-amber-100'
+      : 'border-white/15 bg-black/40 text-white/80';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="transit-source-badge"
+      data-source={source}
+      title={fullHint}
+      className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium tracking-wide backdrop-blur-sm ${toneClass} ${className ?? ''}`}
+    >
+      <span
+        aria-hidden="true"
+        className={`inline-block h-1.5 w-1.5 rounded-full ${
+          source === 'fallback-neutral' ? 'bg-amber-400' : 'bg-white/60'
+        }`}
+      />
+      <span>{copy.label}</span>
+    </div>
+  );
+}

--- a/src/hooks/useSignaturSignal.ts
+++ b/src/hooks/useSignaturSignal.ts
@@ -88,6 +88,8 @@ export const useSignaturSignal = (userId: string): SignaturSignalState => {
         baseSignals,
         thirtyDayAvg,
         transitIntensity,
+        source: transitState._meta?.source ?? 'live',
+        sourceReason: transitState._meta?.reason,
       });
 
       setSignalData(nextSignalData);

--- a/src/lib/schemas/transit-state.ts
+++ b/src/lib/schemas/transit-state.ts
@@ -24,6 +24,34 @@ export const TransitEventSchema = z.object({
   priority: z.number().optional().default(0),
 });
 
+/**
+ * Source marker on transit-state + derived payloads.
+ *
+ * - `live`              — real FuFirE transit response, fully live data
+ * - `fallback-profile`  — FuFirE unreachable, ring synthesized from stored
+ *                         soulprint + small deterministic drift (not live
+ *                         transit, user's natal signature only)
+ * - `fallback-neutral`  — neither FuFirE nor Supabase profile available,
+ *                         ring is pure neutral (worst case, no user data)
+ *
+ * The no-placeholder-fake directive requires the UI to distinguish these
+ * states visibly rather than presenting fallback data as if it were live.
+ */
+export const TransitSourceSchema = z.union([
+  z.literal('live'),
+  z.literal('fallback-profile'),
+  z.literal('fallback-neutral'),
+]);
+
+export type TransitSource = z.infer<typeof TransitSourceSchema>;
+
+export const TransitMetaSchema = z.object({
+  source: TransitSourceSchema,
+  reason: z.string().optional(),
+});
+
+export type TransitMeta = z.infer<typeof TransitMetaSchema>;
+
 export const TransitStateSchema = z.object({
   ring: z.object({ sectors: TwelveNumbers }),
   soulprint: z.object({ sectors: TwelveNumbers }),
@@ -33,6 +61,9 @@ export const TransitStateSchema = z.object({
   }),
   events: z.array(TransitEventSchema).default([]),
   resolution: z.number().min(0).max(100).optional(),
+  // Defaults to `live` for backward-compat on old cached responses, but
+  // current server always sets this explicitly so the UI can trust it.
+  _meta: TransitMetaSchema.optional().default({ source: 'live' }),
 });
 
 export const FusionSignalDataSchema = z.object({
@@ -40,6 +71,8 @@ export const FusionSignalDataSchema = z.object({
   baseSignals: z.array(z.number().min(0).max(1)).length(12),
   thirtyDayAvg: z.array(z.number().min(0).max(1)).length(12),
   transitIntensity: z.number().min(0).max(1),
+  source: TransitSourceSchema.default('live'),
+  sourceReason: z.string().optional(),
 });
 
 export type TransitState = z.infer<typeof TransitStateSchema>;

--- a/src/lib/schemas/transit-state.ts
+++ b/src/lib/schemas/transit-state.ts
@@ -63,7 +63,7 @@ export const TransitStateSchema = z.object({
   resolution: z.number().min(0).max(100).optional(),
   // Defaults to `live` for backward-compat on old cached responses, but
   // current server always sets this explicitly so the UI can trust it.
-  _meta: TransitMetaSchema.optional().default({ source: 'live' }),
+  _meta: TransitMetaSchema.optional().default(() => ({ source: 'live' })),
 });
 
 export const FusionSignalDataSchema = z.object({

--- a/src/lib/schemas/transit-state.ts
+++ b/src/lib/schemas/transit-state.ts
@@ -63,7 +63,11 @@ export const TransitStateSchema = z.object({
   resolution: z.number().min(0).max(100).optional(),
   // Defaults to `live` for backward-compat on old cached responses, but
   // current server always sets this explicitly so the UI can trust it.
-  _meta: TransitMetaSchema.optional().default(() => ({ source: 'live' })),
+  // `as const` preserves the string-literal type through TS widening —
+  // Zod's .default overload demands `'live' | 'fallback-profile' |
+  // 'fallback-neutral'`, a bare `'live'` string widens to `string` on
+  // the strict TS config used in CI and breaks the overload match.
+  _meta: TransitMetaSchema.optional().default({ source: 'live' as const }),
 });
 
 export const FusionSignalDataSchema = z.object({
@@ -71,7 +75,8 @@ export const FusionSignalDataSchema = z.object({
   baseSignals: z.array(z.number().min(0).max(1)).length(12),
   thirtyDayAvg: z.array(z.number().min(0).max(1)).length(12),
   transitIntensity: z.number().min(0).max(1),
-  source: TransitSourceSchema.default('live'),
+  // Same widening guard as TransitStateSchema._meta — see comment there.
+  source: TransitSourceSchema.default('live' as const),
   sourceReason: z.string().optional(),
 });
 

--- a/src/pages/SignaturPage.tsx
+++ b/src/pages/SignaturPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Sparkles, Volume2, VolumeX } from 'lucide-react';
 import { useLanguage } from '@/src/contexts/LanguageContext';
 import { useAppLayout } from '@/src/contexts/AppLayoutContext';
 import { SignaturRenderer } from '@/src/components/signatur-renderer/SignaturRenderer';
+import { TransitSourceBadge } from '@/src/components/signatur/TransitSourceBadge';
 import { usePlanetarium } from '@/src/contexts/PlanetariumContext';
 import QuizOverlay from '@/src/components/QuizOverlay';
 import { useQuizContribution } from '@/src/hooks/useQuizContribution';
@@ -344,6 +345,14 @@ export default function SignaturPage() {
                 eventAnnouncePrefix: t('signatur.eventAnnouncePrefix'),
               }}
             />
+            {signalData && signalData.source !== 'live' && (
+              <div className="flex justify-center">
+                <TransitSourceBadge
+                  source={signalData.source}
+                  reason={signalData.sourceReason}
+                />
+              </div>
+            )}
             {chladniParams && (
               <ChladniParamsBadge
                 params={chladniParams}


### PR DESCRIPTION
## Summary
Until today `/api/transit-state` degraded silently: when FuFirE returned 503 the server responded with HTTP 200 + a synthesized ring derived from the user's stored natal soulprint (or pure neutral if no profile existed). The only signal was the `X-Transit-Fallback` header, which the frontend never read. Users saw what the UI calls a **"Live-Divergenzfeld"** but were actually looking at static natal data — exactly the placeholder-fake pattern the directive forbids.

This PR propagates an explicit `source` marker through the full stack and renders a small transparency badge on the Signatur page when the data is not live.

## Changes

**Server** (`server.mjs`)
- Success path returns `_meta: { source: 'live' }` in the body.
- `respondWithFallback` returns `_meta: { source: 'fallback-profile' | 'fallback-neutral', reason }`. Existing `X-Transit-Fallback` header kept for backward compat with debug tooling.

**Schema** (`src/lib/schemas/transit-state.ts`)
- `TransitSourceSchema` union of the three states.
- `TransitStateSchema._meta` optional, defaults to `{source:'live'}` so cached responses from before this change don't false-positive as fallback.
- `FusionSignalDataSchema.source` + `.sourceReason` threaded through `useSignaturSignal` parse step.

**UI** (`src/components/signatur/TransitSourceBadge.tsx` + `SignaturPage.tsx`)
- Badge renders **nothing on `live`**, a visible pill on either fallback variant with DE+EN copy. Neutral variant uses amber tone so users perceive it as more alarming than the profile-derived fallback.
- Mounted on SignaturPage below the renderer, wrapped in `aria-live="polite"` status role so screen readers announce state changes quietly.

## Test plan
- [x] `npm run typecheck:src` — clean
- [x] `npx vitest run` — 1969/1970 (one pre-existing `vibes-perf` failure, unrelated)
- 11 new tests:
  - Badge: live → renders nothing, fallback-profile shows DE label, fallback-neutral shows DE label + amber tone, reason appended to tooltip hint, aria attributes present.
  - Schema: live / fallback-profile / fallback-neutral all parse, legacy payloads without `_meta` default to live, unknown source values rejected, FusionSignalData source+reason roundtrip.

## Follow-up
Apply the same transparency pattern to:
- `/api/experience/daily` — when it falls back to local placeholder horoscope text
- `/api/experience/bootstrap` — when the chart fetch falls back to synthetic soulprint

Separate PR once this pattern is merged and validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)