### PR TITLE
fix: gate daily-horoscope auto-open to morning window, respect user locale, and default Signatur to 3D

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -293,7 +293,8 @@ export function Dashboard({
     effectiveSoulprint,
     profileMeta.quizSectors,
     birthSign,
-    skyMode === 'current' ? currentDate.toISOString().split('T')[0] : undefined
+    skyMode === 'current' ? currentDate.toISOString().split('T')[0] : undefined,
+    lang === 'en' ? 'en-US' : 'de-DE',
   );
 
   // Night-Pulse gate: weekends → all users; weekdays → Premium only.

--- a/src/components/signatur-renderer/SignaturRenderer.tsx
+++ b/src/components/signatur-renderer/SignaturRenderer.tsx
@@ -86,7 +86,7 @@ export const SignaturRenderer = ({
   const { kpIndex } = useSpaceWeather();
 
   const [cymaticsFailed, setCymaticsFailed] = useState(false);
-  const [viewMode, setViewMode] = useState<'2d' | '3d'>('2d');
+  const [viewMode] = useState<'2d' | '3d'>('3d');
 
   const resolutionText = `${labels.resolution}: ${Math.round(resolution)}%`;
 
@@ -110,36 +110,6 @@ export const SignaturRenderer = ({
           : 'border-slate-200 bg-[#f1f5f9]'
       }`}
     >
-      {/* 2D ↔ 3D view toggle. Absolute-positioned so it floats above whichever
-          canvas is visible without pushing the layout. aria-pressed reflects
-          the active mode for assistive tech. */}
-      <div
-        role="group"
-        aria-label="Ansichtsmodus"
-        className="absolute right-3 top-3 z-20 flex items-center rounded-full border border-white/15 bg-black/50 p-1 text-[11px] font-semibold backdrop-blur-sm"
-      >
-        <button
-          type="button"
-          onClick={() => setViewMode('2d')}
-          aria-pressed={viewMode === '2d'}
-          className={`rounded-full px-3 py-1 transition-colors ${
-            viewMode === '2d' ? 'bg-white/15 text-white' : 'text-white/50 hover:text-white/80'
-          }`}
-        >
-          2D
-        </button>
-        <button
-          type="button"
-          onClick={() => setViewMode('3d')}
-          aria-pressed={viewMode === '3d'}
-          className={`rounded-full px-3 py-1 transition-colors ${
-            viewMode === '3d' ? 'bg-white/15 text-white' : 'text-white/50 hover:text-white/80'
-          }`}
-        >
-          3D
-        </button>
-      </div>
-
       <div className="relative flex h-[55vh] min-h-[340px] w-full max-h-[700px] items-center justify-center sm:h-[62vh] sm:min-h-[420px] sm:max-h-[760px]">
         {loading && !signalData && (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/45 text-xs uppercase tracking-[0.2em] text-white/70">

--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -118,6 +118,7 @@ export function useFirstRunDaily(
   quizSectors: number[],
   birthSign: string | null,
   customDate?: string, // YYYY-MM-DD
+  locale: string = 'de-DE',
 ): UseFirstRunDailyResult {
   const [dailyData, setDailyData] = useState<DailyResponse | null>(null);
   const [showModal, setShowModal] = useState(false);
@@ -125,6 +126,10 @@ export function useFirstRunDaily(
   const lastFetchedDateRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const now = new Date();
+    const currentHour = now.getHours();
+    const isTodayTarget = !customDate || customDate === todayKey();
+    const isWithinDeliveryWindow = currentHour >= 6 && currentHour < 18;
     const targetDate = customDate || todayKey();
 
     // Guard: need userId + birthData; soulprint can be null (synthetic fallback).
@@ -162,7 +167,7 @@ export function useFirstRunDaily(
           const cached = getCachedDaily();
           if (cached) {
             setDailyData(cached);
-            if (!alreadySeen) setShowModal(true);
+            if (!alreadySeen && isWithinDeliveryWindow) setShowModal(true);
             return;
           }
         }
@@ -185,7 +190,7 @@ export function useFirstRunDaily(
           soulprintSectors ?? Array(12).fill(0.5),
           quizSectors,
           targetDate,
-          'de-DE',
+          locale,
           transitInfluences,
           birthSign ?? '',
         );
@@ -194,7 +199,7 @@ export function useFirstRunDaily(
 
         if (isToday) setCachedDaily(data);
         setDailyData(data);
-        if (!alreadySeen) setShowModal(true);
+        if (!alreadySeen && (!isTodayTarget || isWithinDeliveryWindow)) setShowModal(true);
       } catch (err) {
         // Graceful fallback: use local deterministic daily so DashboardTagesEnergie always renders
         console.warn('[useFirstRunDaily] Error occurred, using local fallback:', err);
@@ -203,7 +208,7 @@ export function useFirstRunDaily(
           // Adjust fallback date to target
           fallback.date = targetDate;
           setDailyData(fallback);
-          if (!alreadySeen) setShowModal(true);
+          if (!alreadySeen && (!isTodayTarget || isWithinDeliveryWindow)) setShowModal(true);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -213,7 +218,7 @@ export function useFirstRunDaily(
     return () => {
       cancelled = true;
     };
-  }, [userId, birthData, soulprintSectors, quizSectors, birthSign, customDate]);
+  }, [userId, birthData, soulprintSectors, quizSectors, birthSign, customDate, locale]);
 
   const handleClose = useCallback(() => {
     setShowModal(false);


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass das Tageshoroskop zwar täglich generiert wird, aber das Auto‑Öffnen des Modals nur innerhalb des beabsichtigten Morgenschlitzes erfolgt (ab 06:00 lokal) und das Dashboard die Inhalte jederzeit inline laden kann.
- Die sprachliche Ausgabe des Tageshoroskops an die vom Nutzer gewählte Sprache koppeln statt hartkodiertes Deutsch zu verwenden.
- Die neue 3D‑Kugel‑Signatur als primäre/alleinige Darstellung durchsetzen und das alte 2D‑Toggle zu entfernen, damit die Visualisierung konsistent dem Geburtschart folgt.
- Kurz geprüft: die Aphorismen‑Selektion existiert in `src/lib/daily-pulse`, war aber nicht aktiv als Modal‑Trigger‑Pfad involviert und wurde daher nicht neu verdrahtet.

### Description
- Ändert die Hook `useFirstRunDaily` (`src/hooks/useFirstRunDaily.ts`) um einen optionalen `locale`-Parameter und fügt eine lokale Delivery‑Window‑Prüfung (`currentHour >= 6 && currentHour < 18`) ein, die das Auto‑Öffnen des Daily‑Modals für Same‑Day‑Payloads gate.
- Stellt sicher, dass die tägliche Fetch‑Aufrufsprache an `fetchDailyExperience` übergeben wird (Dashboard übergibt `lang === 'en' ? 'en-US' : 'de-DE'`) anstatt `de-DE` zu hardcoden (`src/components/Dashboard.tsx`).
- Erzwingt die 3D‑Signaturansicht im Renderer, entfernt den 2D/3D Umschalter und startet fest in 3D (`src/components/signatur-renderer/SignaturRenderer.tsx`).
- Erhält das bestehende Caching‑/Fallback‑Verhalten so, dass Inhalte weiterhin inline geladen und gecached werden, auch wenn die Auto‑Modal‑Ausspielung außen vor bleibt.

### Testing
- `npm run lint` (TypeScript `tsc --noEmit`) wurde ausgeführt und lief erfolgreich nach den Anpassungen.
- Es wurden keine neuen Unit‑Tests hinzugefügt und keine weiteren automatisierten Tests im PR ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f399685af883229eb890ac1612900a)

## Summary by Sourcery

Gate the daily horoscope auto-open behavior by local time and locale while standardizing the signature renderer on the 3D view.

Bug Fixes:
- Restrict automatic opening of the daily horoscope modal for same-day content to a local morning/ daytime window while still allowing inline loading and caching.
- Use the user-selected language/locale when fetching the daily experience instead of always requesting German content.

Enhancements:
- Make the 3D signature view the default and only rendering mode by removing the 2D/3D toggle in the signature renderer.