### PR TITLE
fix: normalize dominant Wu‑Xing element keys to prevent signature sphere crash

### DIFF
--- a/src/__tests__/cymatics-bridge.test.ts
+++ b/src/__tests__/cymatics-bridge.test.ts
@@ -274,6 +274,22 @@ describe('baziToChladniParams — dominant element', () => {
     const { dominantElement } = baziToChladniParams(pillars, {}, 0.5);
     expect(dominantElement).toBe('Water');
   });
+
+
+  it('normalizes lowercase and localized element keys', () => {
+    const pillars = {
+      year:  makePillar('甲'),
+      month: makePillar('乙'),
+      day:   makePillar('丙'),
+      hour:  makePillar('丁'),
+    };
+    const { dominantElement } = baziToChladniParams(
+      pillars,
+      { water: 0.2, feuer: 0.81, metal: 0.1 },
+      0.5,
+    );
+    expect(dominantElement).toBe('Fire');
+  });
 });
 
 // ── baziToChladniParams — unknown stem fallback ──────────────────────────────

--- a/src/lib/cymatics/bazi-to-chladni.ts
+++ b/src/lib/cymatics/bazi-to-chladni.ts
@@ -44,6 +44,59 @@ export const ELEMENT_COLORS: Record<WuxingElement, string> = {
   Water: '#42A5F5',
 };
 
+
+
+const CANONICAL_WUXING_ELEMENTS: readonly WuxingElement[] = ['Wood', 'Fire', 'Earth', 'Metal', 'Water'] as const;
+
+function normalizeWuxingElementKey(raw: string): WuxingElement | null {
+  const key = raw.trim().toLowerCase();
+  switch (key) {
+    case 'wood':
+    case 'holz':
+      return 'Wood';
+    case 'fire':
+    case 'feuer':
+      return 'Fire';
+    case 'earth':
+    case 'erde':
+      return 'Earth';
+    case 'metal':
+    case 'metall':
+      return 'Metal';
+    case 'water':
+    case 'wasser':
+      return 'Water';
+    default:
+      return null;
+  }
+}
+
+function dominantElementFromWeights(wuxingWeights: Record<string, number>): WuxingElement {
+  let best: WuxingElement = 'Water';
+  let bestValue = Number.NEGATIVE_INFINITY;
+
+  for (const el of CANONICAL_WUXING_ELEMENTS) {
+    const v = Number(wuxingWeights[el] ?? Number.NEGATIVE_INFINITY);
+    if (v > bestValue) {
+      best = el;
+      bestValue = v;
+    }
+  }
+
+  for (const [rawKey, rawValue] of Object.entries(wuxingWeights)) {
+    const el = normalizeWuxingElementKey(rawKey);
+    if (!el) continue;
+    const v = Number(rawValue);
+    if (!Number.isFinite(v)) continue;
+    if (v > bestValue) {
+      best = el;
+      bestValue = v;
+    }
+  }
+
+  return best;
+}
+
 /**
  * Heavenly Stem name → index 0..9.
  * This is the PRIMARY lookup because MappedPillar.stem is a string
@@ -122,9 +175,7 @@ export function baziToChladniParams(
   const a = 0.3 + harmonyIndex * 0.7;                      // 0.30..1.00
   const b = 1.0 - a * 0.6;                                 // ~0.40..0.82
 
-  const dominantElement = (
-    Object.entries(wuxingWeights).sort(([, v1], [, v2]) => v2 - v1)[0]?.[0] ?? 'Water'
-  ) as WuxingElement;
+  const dominantElement = dominantElementFromWeights(wuxingWeights);
 
   return { m, n, a, b, dominantElement, harmonyIndex };
 }


### PR DESCRIPTION
### Motivation
- The 3D signature material expects one of the canonical Wu‑Xing keys (`Wood|Fire|Earth|Metal|Water`), but `apiData.wuxing.elements` could contain lowercase or localized keys, causing a lookup of `MATERIAL_PROPS[element]` to be `undefined` and crashing when reading `specStrength`.
- The goal is to ensure the derived `dominantElement` is always a validated canonical `WuxingElement` so the renderer never receives an invalid key.

### Description
- Added `normalizeWuxingElementKey` and `dominantElementFromWeights` helper logic to `src/lib/cymatics/bazi-to-chladni.ts` to map lowercase and localized keys (e.g. `feuer`, `wasser`, `holz`) to canonical `WuxingElement` values.
- Replaced the previous unsafe cast-based extraction of `dominantElement` with the robust `dominantElementFromWeights` selection so only valid element keys are returned.
- Added a regression test `it('normalizes lowercase and localized element keys')` in `src/__tests__/cymatics-bridge.test.ts` to verify normalization of non-canonical keys.
- No changes were made to the rendering/material code surface; the fix ensures the existing `buildWuxingMaterial` always receives a supported element.

### Testing
- Ran type-checking with `npm run lint`, which completed successfully (TS compile check `--noEmit`).
- Ran the file tests with `npm run test -- src/__tests__/cymatics-bridge.test.ts`, and the test run passed (the test file ran and all tests succeeded).
- Verified the added unit test covers lowercase/localized keys and passes under the test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f53caa588c8322a30af447786f3167)

## Summary by Sourcery

Normalize Wu-Xing element keys when deriving the dominant element to prevent crashes in the signature sphere renderer.

Bug Fixes:
- Ensure dominant Wu-Xing element selection only returns validated canonical elements even when input weights use lowercase or localized keys.

Enhancements:
- Introduce helper utilities to normalize Wu-Xing element keys and deterministically compute the dominant element from weight maps.

Tests:
- Add a regression test verifying that lowercase and localized Wu-Xing element keys are normalized to their canonical forms when determining the dominant element.