### PR TITLE
fix: prevent repeated frontend crashes from transient API/element failures

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -3819,6 +3819,7 @@ function estimateSolarCyclePhase(f107) {
 }
 
 app.get("/api/space-weather/extended", async (_req, res) => {
+  try {
   res.set("Cache-Control", "public, max-age=300");
 
   const now = Date.now();
@@ -4110,6 +4111,21 @@ app.get("/api/space-weather/extended", async (_req, res) => {
   extendedWeatherCache = { timestamp: now, payload };
   console.log(`[space-weather/extended] Kp=${kpValue} (${kpSource}), xray=${xrayClass}, events=${activeEvents.length}, f107=${f107}`);
   return res.json(payload);
+  } catch (err) {
+    console.error("[space-weather/extended] unhandled error:", err?.message || err);
+    return res.status(200).json({
+      current: { kp: 0, kpForecast3h: [], xrayFlux: 0, xrayClass: "A", protonFlux: 0 },
+      events: [],
+      alerts: [],
+      epoch: { sunspotNumber: 0, f107: 0, solarCyclePhase: "minimum" },
+      meta: {
+        fetchedAt: new Date().toISOString(),
+        noaaVersion: "v1",
+        cacheTtlSeconds: Math.round(EXTENDED_CACHE_TTL_MS / 1000),
+        degraded: true,
+      },
+    });
+  }
 });
 
 // ── /api/space-weather/timeline ─────────────────────────────────────

--- a/src/lib/signatur-3d/wuxing-material.ts
+++ b/src/lib/signatur-3d/wuxing-material.ts
@@ -71,7 +71,7 @@ export function buildWuxingMaterial(options: WuxingMaterialOptions): THREE.Shade
   let currentElement = safeElement;
   let isDark = planetariumMode;
   const element = safeElement;
-  const props = MATERIAL_PROPS[element];
+  const props = MATERIAL_PROPS[element] ?? MATERIAL_PROPS.Water;
 
   const material = new THREE.ShaderMaterial({
     vertexShader: VERTEX_SHADER,
@@ -94,7 +94,7 @@ export function buildWuxingMaterial(options: WuxingMaterialOptions): THREE.Shade
   (material.userData as WuxingMaterialUserData).updateElement = (el: WuxingElement) => {
     const safeEl = coerceWuxingElement(el);
     currentElement = safeEl;
-    const p = MATERIAL_PROPS[safeEl];
+    const p = MATERIAL_PROPS[safeEl] ?? MATERIAL_PROPS.Water;
     material.uniforms.u_element.value = ELEMENT_INDEX[safeEl];
     material.uniforms.u_plasticity.value = PLASTICITY[safeEl];
     material.uniforms.u_specStrength.value = p.specStrength;


### PR DESCRIPTION
### Motivation
- Frontend was crashing with `TypeError: Cannot read properties of undefined (reading 'specStrength')` when an unexpected Wu-Xing element key reached the 3D material builder. 
- `/api/space-weather/extended` could return HTTP 500 on unhandled errors which caused noisy polling retries and error-boundary resets. 

### Description
- Add defensive fallbacks in `buildWuxingMaterial` so lookups into `MATERIAL_PROPS` use `MATERIAL_PROPS.Water` when an entry is missing, preventing undefined `specStrength`/`specExp` access in `src/lib/signatur-3d/wuxing-material.ts`. 
- Wrap the entire `/api/space-weather/extended` handler in a top-level `try/catch` and return a neutral, degraded payload (preserving the endpoint shape) with `meta.degraded: true` instead of propagating an HTTP 500 in `server.mjs`. 
- Preserve existing cache and logging behavior while improving observability of fallback mode via the `meta.degraded` flag. 

### Testing
- Ran `npm run lint` which executed `tsc --noEmit` and completed successfully. 
- No additional automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6bae1f28883229f6153385dceb32f)

## Summary by Sourcery

Handle unexpected Wu-Xing element keys and harden the space weather extended API against unhandled errors to prevent frontend crashes and noisy retries.

Bug Fixes:
- Fallback to a default Wu-Xing material definition when a requested element is missing to avoid undefined property accesses in the 3D shader material builder.
- Wrap the /api/space-weather/extended handler in a top-level try/catch and return a degraded but well-formed response instead of HTTP 500 on unexpected errors.

Enhancements:
- Preserve existing caching and logging for the extended space weather endpoint while adding a meta.degraded flag to indicate fallback mode in responses.