### PR TITLE
fix(server): catch self-heal persist promise rejection

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2101,6 +2101,9 @@ async function computeActiveImpactsCore(userId) {
             if (persistErr) {
               console.warn('[impact/active] Self-heal persist failed:', persistErr.message);
             }
+          })
+          .catch((persistErr) => {
+            console.warn('[impact/active] Self-heal persist failed:', persistErr?.message || persistErr);
           });
       }
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Prevent unhandled promise rejections from the fire-and-forget self-heal Supabase update in `computeActiveImpactsCore`, so transient Supabase/network failures do not produce uncaught rejections or destabilize the Node process.

### Description
- Add an explicit `.catch(...)` to the existing `supabaseServer.from(...).update(...).then(...)` chain that persists the healed `fusion` block, logging any rejection message while preserving the current in-memory healed value and existing `.then` logic.

### Testing
- Ran `npx vitest run impact-coherence-nested-path.test.ts`, which passed (1 file, 8 tests) indicating the regression tests around harmony-index extraction and self-heal behavior remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f12244202c83229764122a27fa50e3)

## Summary by Sourcery

Bug Fixes:
- Ensure self-heal Supabase update promise rejections are caught and logged instead of becoming unhandled.