### PR TITLE
fix: centralize completed module persist error handling

### DIFF
--- a/src/hooks/useCompletedModules.ts
+++ b/src/hooks/useCompletedModules.ts
@@ -78,18 +78,24 @@ export function useCompletedModules() {
     // Schema: contribution_events has event_id (UNIQUE NOT NULL), occurred_at (NOT NULL),
     // payload (JSONB NOT NULL). sector_weights lives inside payload.
     const eventId = `${moduleId}:${user.id}:individual`;
-    supabase
-      .from('contribution_events')
-      .upsert({
-        user_id: user.id,
-        event_id: eventId,
-        module_id: moduleId,
-        occurred_at: new Date().toISOString(),
-        payload: { sector_weights: Array(12).fill(0), confidence: 0 },
-      }, { onConflict: 'user_id,module_id' })
-      .then(({ error }) => {
-        if (error) console.warn('[useCompletedModules] Individual persist failed:', error.message);
-      });
+    void (async () => {
+      try {
+        const { error } = await supabase
+          .from('contribution_events')
+          .upsert({
+            user_id: user.id,
+            event_id: eventId,
+            module_id: moduleId,
+            occurred_at: new Date().toISOString(),
+            payload: { sector_weights: Array(12).fill(0), confidence: 0 },
+          }, { onConflict: 'user_id,module_id' });
+
+        if (error) throw error;
+      } catch (persistErr: unknown) {
+        const persistMessage = persistErr instanceof Error ? persistErr.message : String(persistErr);
+        console.warn('[useCompletedModules] Individual persist failed:', persistMessage, persistErr);
+      }
+    })();
   }, [user]);
 
   return { completedModuleIds, loading, addModule };


### PR DESCRIPTION
### Motivation
- Centralize and simplify the fire-and-forget Supabase persistence path for per-module completions to avoid duplicate/error-prone logging paths and inconsistent behavior. 
- Also fix a TypeScript/typing issue surfaced by using `.catch` on a `PromiseLike` result and improve debuggability for non-`Error` failure values.

### Description
- Replaced the `supabase...upsert().then(...).catch(...)` flow in `src/hooks/useCompletedModules.ts` with an `async` IIFE started with `void` and a single `try/catch` block to centralize handling. 
- Throw when Supabase returns an `error` so all persistence failures are handled in the same `catch` branch. 
- Improved logging in the `catch` to emit both a normalized message and the full error object (`persistErr`) for better diagnostics with non-`Error` failures.

### Testing
- Ran `npm run lint` (which runs `tsc --noEmit`) and it succeeded with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f83e41b39083228bc498a2528540de)

## Summary by Sourcery

Bug Fixes:
- Ensure all Supabase upsert persistence failures for individual module completions are consistently caught and logged, including non-Error failure values.