### PR TITLE
Fix apiLimiter skip matching for mounted /api routes

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -326,8 +326,8 @@ app.use('/api/', (req, res, next) => {
 // 429 on the very next call. Bump the general bucket and exempt the
 // known high-frequency polling GETs so they don't starve write endpoints.
 const HIGH_FREQ_POLL_PREFIXES = [
-  "/api/transit-state/",
-  "/api/space-weather",
+  "/transit-state/",
+  "/space-weather",
 ];
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 min


### PR DESCRIPTION
### Motivation
- The rate limiter intended to exempt high-frequency dashboard polling endpoints but compared `req.path` against absolute `/api/...` prefixes while the limiter is mounted with `app.use('/api/', ...)`, so the `startsWith` check never matched and polling traffic still consumed the shared bucket.

### Description
- Update `HIGH_FREQ_POLL_PREFIXES` in `server.mjs` to use subpaths `"/transit-state/"` and `"/space-weather"` so the `skip` predicate using `req.path.startsWith(...)` correctly exempts those GET polling routes when `app.use('/api/', apiLimiter)` is applied.

### Testing
- Performed a syntax check with `node --check server.mjs`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8301bfd988322963c5dd30f51142e)

## Summary by Sourcery

Bug Fixes:
- Correct high-frequency polling route prefixes so they are properly skipped by the shared API rate limiter instead of consuming rate limit tokens.