### PR TITLE
[PR #283 follow-up] Fix wrapped astro_json recompute input in soulprint backfill

### DIFF
--- a/scripts/backfill-soulprint.mjs
+++ b/scripts/backfill-soulprint.mjs
@@ -91,7 +91,7 @@ for (const { user_id, astro_json } of candidates) {
 
   let sectors;
   try {
-    sectors = recomputeSoulprintFromAstroJson(astro_json);
+    sectors = recomputeSoulprintFromAstroJson(chart);
   } catch (err) {
     console.log(`  [FAIL] ${user_id}: recompute threw — ${err.message}`);
     failed++;


### PR DESCRIPTION
### Motivation
- The backfill script could silently produce and persist invalid all-zero soulprint sectors for rows whose stored `astro_json` is wrapped as `{ bafe: { ... } }` because recomputation used the raw payload rather than the normalized chart object.
- The intent is to include wrapped payloads as eligible candidates and ensure recompute uses the same normalized chart shape used for the eligibility gate so wrapped records are computed correctly.

### Description
- Compute a normalized chart with `const chart = astro_json.bafe || astro_json` and use it for eligibility checks (`chart?.bazi`, `chart?.western`, `chart?.wuxing`).
- Pass the normalized `chart` into `recomputeSoulprintFromAstroJson(chart)` instead of the raw `astro_json` so wrapped `{ bafe: ... }` rows are recomputed from the intended subfields.
- Change is localized to `scripts/backfill-soulprint.mjs` and preserves the existing recompute/persist flow and validation.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8496768248322bd233483ff023f35)

## Summary by Sourcery

Bug Fixes:
- Fix soulprint backfill recomputation to use the normalized chart instead of the raw astro_json, preventing invalid sectors for wrapped payloads.