### PR TITLE
Fix soulprint backfill recomputation to normalize wrapped chart payloads

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -130,7 +130,11 @@ async function waitForStoredChart(userId, maxAttempts = 25, waitMs = 800) {
  * @returns {number[]} 12-element array
  */
 export function recomputeSoulprintFromAstroJson(astroJson) {
-  const nDim = computeNatalDimensions(astroJson);
+  const normalizedChart = extractStoredChart(astroJson);
+  if (!normalizedChart) {
+    throw new Error("invalid_astro_json");
+  }
+  const nDim = computeNatalDimensions(normalizedChart);
   const qDim = zeroDimensions();
   return projectToRing(nDim, qDim, 1, 0);
 }

--- a/src/__tests__/persist-soulprint-sectors.test.ts
+++ b/src/__tests__/persist-soulprint-sectors.test.ts
@@ -161,17 +161,27 @@ describe('recomputeSoulprintFromAstroJson', () => {
 
     const normalizedChart = {
       bazi: { day_master: 'wood', season: 'spring' },
-      western: { zodiac_sign: 'aries', moon_sign: 'leo', ascendant: 'sagittarius' },
-      wuxing: { dominant: 'wood', distribution: { wood: 0.5, fire: 0.2, earth: 0.1, metal: 0.1, water: 0.1 } },
+      western: { zodiac_sign: 'Aries', moon_sign: 'Leo', ascendant_sign: 'Sagittarius' },
+      wuxing: { dominant: 'wood' },
     };
 
     const wrapped = {
       bafe: normalizedChart,
-      western: { zodiac_sign: 'pisces', moon_sign: 'cancer', ascendant: 'taurus' },
+      western: { zodiac_sign: 'Pisces', moon_sign: 'Cancer', ascendant_sign: 'Taurus' },
       wuxing: { dominant: 'water' },
-      bazi: { day_master: 'water' },
+      bazi: { day_master: 'water', season: 'winter' },
     };
 
-    expect(recompute(wrapped)).toEqual(recompute(normalizedChart));
+    const topLevelOnlyChart = {
+      western: wrapped.western,
+      wuxing: wrapped.wuxing,
+      bazi: wrapped.bazi,
+    };
+
+    const normalized = recompute(normalizedChart);
+
+    expect(normalized.some((value) => value !== 0)).toBe(true);
+    expect(recompute(topLevelOnlyChart)).not.toEqual(normalized);
+    expect(recompute(wrapped)).toEqual(normalized);
   });
 });

--- a/src/__tests__/persist-soulprint-sectors.test.ts
+++ b/src/__tests__/persist-soulprint-sectors.test.ts
@@ -145,3 +145,33 @@ describe('persistSoulprintSectors', () => {
     );
   });
 });
+
+
+describe('recomputeSoulprintFromAstroJson', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    vi.resetModules();
+  });
+
+  it('normalizes wrapped astro_json payloads via .bafe before recomputation', async () => {
+    const mod = await import('../../server.mjs');
+    const recompute = mod.recomputeSoulprintFromAstroJson as (astroJson: unknown) => number[];
+
+    const normalizedChart = {
+      bazi: { day_master: 'wood', season: 'spring' },
+      western: { zodiac_sign: 'aries', moon_sign: 'leo', ascendant: 'sagittarius' },
+      wuxing: { dominant: 'wood', distribution: { wood: 0.5, fire: 0.2, earth: 0.1, metal: 0.1, water: 0.1 } },
+    };
+
+    const wrapped = {
+      bafe: normalizedChart,
+      western: { zodiac_sign: 'pisces', moon_sign: 'cancer', ascendant: 'taurus' },
+      wuxing: { dominant: 'water' },
+      bazi: { day_master: 'water' },
+    };
+
+    expect(recompute(wrapped)).toEqual(recompute(normalizedChart));
+  });
+});


### PR DESCRIPTION
### Motivation
- The backfill previously passed the raw `astro_json` into the recomputation pipeline which could include wrapper-level fields (e.g. `astro_json.bafe`), producing invalid sector arrays for wrapped payloads.
- The intent is to ensure the backfill uses the canonical/normalized chart object so derived soulprint sectors are valid and deterministic.

### Description
- Change `recomputeSoulprintFromAstroJson` in `server.mjs` to call `extractStoredChart(astroJson)` and throw `invalid_astro_json` when normalization fails, then compute natal dimensions from the normalized chart before projecting to the 12-sector ring via `projectToRing`.
- Add a regression test in `src/__tests__/persist-soulprint-sectors.test.ts` that verifies a wrapped payload with a `bafe` wrapper recomputes identically to the normalized chart object.

### Testing
- Ran the targeted Vitest file with `pnpm vitest run src/__tests__/persist-soulprint-sectors.test.ts` and the suite completed with all tests passing (1 file, 7 tests passed).
- The new test confirms wrapped `astro_json` payloads are normalized via `.bafe` prior to recomputation and that the recomputed sectors match the normalized-chart computation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f84ad1c6e08322b57c0259518f125f)

## Summary by Sourcery

Normalize astro_json payloads before recomputing soulprint sectors to ensure deterministic results and add regression coverage for wrapped charts.

Bug Fixes:
- Fix soulprint recomputation to derive natal dimensions from the normalized chart rather than raw wrapped astro_json payloads, rejecting invalid inputs.

Tests:
- Add regression test verifying wrapped astro_json payloads with a bafe wrapper recompute identically to their normalized chart equivalents.