### PR TITLE
[PR #314 follow-up] Restore rate limiting for expensive API routes

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -315,9 +315,6 @@ app.use('/api/', (req, res, next) => {
 // ── Rate Limiting ────────────────────────────────────────────────────
 const HIGH_FREQUENCY_API_PREFIXES = [
   "/transit-state",
-  "/impact/active",
-  "/experience/daily",
-  "/vibes",
 ];
 
 const apiLimiter = rateLimit({


### PR DESCRIPTION
### Motivation
- The `skip` predicate for the global `apiLimiter` accidentally excluded `/impact/active`, `/experience/daily`, and `/vibes`, removing rate-limit protection from expensive authenticated handlers that perform external/model work.

### Description
- Updated `server.mjs` by trimming `HIGH_FREQUENCY_API_PREFIXES` to only include `"/transit-state"`, causing the global `apiLimiter` (100 requests / 15 minutes) to once again apply to `/impact/active`, `/experience/daily`, and `/vibes`.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f84f4844708322b1a2c470221843d2)

## Summary by Sourcery

Bug Fixes:
- Reinstate the standard API rate limiter for the /impact/active, /experience/daily, and /vibes endpoints by removing them from the high-frequency API prefix exemptions.