### PR TITLE
fix(dashboard): handle self-heal persist rejections

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2093,7 +2093,7 @@ async function computeActiveImpactsCore(userId) {
         // existing bazi/western/wuxing keys. Errors here are swallowed — the
         // in-memory rawHarmony is already usable for the current response.
         const mergedAstro = { ...profile.astro_json, fusion: fusionResp };
-        supabaseServer
+        void supabaseServer
           .from('astro_profiles')
           .update({ astro_json: mergedAstro })
           .eq('user_id', userId)
@@ -2102,6 +2102,8 @@ async function computeActiveImpactsCore(userId) {
               console.warn('[impact/active] Self-heal persist failed:', persistErr.message);
             }
           })
+          // Explicitly handle fire-and-forget rejections so transient Supabase
+          // failures remain non-fatal and never surface as unhandled rejections.
           .catch((persistErr) => {
             console.warn('[impact/active] Self-heal persist failed:', persistErr?.message || persistErr);
           });


### PR DESCRIPTION
### Motivation
- Prevent an unhandled-promise rejection from the fire-and-forget Supabase persist in the coherence self-heal path which could destabilize the Node process.

### Description
- In `server.mjs` `computeActiveImpactsCore` mark the self-heal persist as intentional fire-and-forget with `void` and keep an explicit `.catch(...)` with a comment so transient Supabase/network errors are logged and never surface as unhandled rejections.

### Testing
- Ran `npx vitest run src/__tests__/impact-coherence-nested-path.test.ts` and all tests passed (8/8).
- Ran `npx tsc --noEmit` and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb30de601c83229c16dc2ec3cf656f)

## Summary by Sourcery

Bug Fixes:
- Ensure the fire-and-forget Supabase self-heal update is explicitly marked and fully handled so transient persistence failures do not surface as unhandled promise rejections.