### PR TITLE
Dashboard Stability Hotfixes (PR 1 of dashboard-flow plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [Unreleased] - 2026-05-07 — Dashboard Stability Hotfixes (PR 1 of dashboard-flow-tagespuls plan)
+
+### Bug fixes
+
+- **`/signatur` no longer crashes** (`src/components/signatur-3d/SignatureSphere3D.tsx`) — react-three-fiber's `applyProps` treats unknown JSX attributes on `<mesh>`/`<group>` as Three.js property setters. `data-tint="gold"` and three `data-mesh-role` attributes (lines 373, 390-391, 411 from April commit `33a1119`) triggered `Uncaught Error: R3F: Cannot set "data-tint"`. The page-level `ErrorBoundary` caught it and rendered "Etwas ist schiefgelaufen" instead of the Chladni sphere. **This was the actual root cause of the user-reported "Signatur kaputt"** — not a data-flow issue. Removed the data-* attrs (they were non-functional on R3F nodes anyway — CSS selectors don't reach `Three.Object3D`). Source-level guard tests prevent re-introduction. Three sibling tests in `SignatureSphere3D.test.tsx` (Task-5b/5c/6 additions) that asserted the `[data-mesh-role]` / `[data-tint]` selectors were deleted — they only passed because the test file's Canvas mock short-circuits R3F's `applyProps`, letting the attrs fall through to JSDOM. They validated the bug, not the feature, and violated the file's own scope statement ("Internal scene-graph coverage beyond that is out of scope").
+- **`/api/experience/daily` cache no longer poisoned by fallback payloads** (`server.mjs`) — when the AI router fully exhausts (Gemini 429 + OpenRouter unset/exhausted/empty payload/malformed JSON), the daily handler falls back to `buildDailyFallbackPayload()`. Previously that fallback was written into both the L1 in-memory `horoscopeCache` and the L2 `daily_horoscope_cache` Supabase table — for the next 24h every request for the same `(user, date, lang)` returned the cached generic text without retrying the AI router. Even after the Gemini quota reset, users saw the generic "Heute fließt deine Energie ruhig…" all day. Fix: gate both cache writes on `parsedData.meta.engine_version !== 'v1-server-fallback'`. Real AI responses cache as before; fallback responses go to the client without poisoning the cache, forcing a retry on the next request. Original plan's HOTFIX-B (OpenRouter fallback + 24h cache) was already implemented in `server/ai-router.mjs` and `server.mjs:1563` — the live investigation surfaced this narrower bug.
+
+### Features
+
+- **Visible fallback indicator on `DailyChartHero`** (`src/components/dashboard/DailyChartHero.tsx`, `src/components/Dashboard.tsx`) — new optional `isFallback` prop. When `useFirstRunDaily()` falls back to `buildFallbackDaily()` (FuFirE/Gemini outage), Dashboard now passes `isFallback={dailyData?.meta?.engine_version === 'v1-local-fallback'}`. Hero renders a 9px-opacity-40% line under the impuls paragraph: `"↻ Heute nicht verfügbar — generischer Inhalt"` (DE) / `"↻ Unavailable today — generic content"` (EN). Real API response → no label. Profile-incomplete → no label (different state already handled).
+- **Em-dash placeholders for null space-weather drivers** (`src/components/dashboard/DailyChartHero.tsx`) — Driver Strip values (Kp, solar pressure, transit count) now render `—` when nullish/non-finite instead of crashing on `.toFixed()` or showing `NaN%`. Belt-and-braces guard for upstream NOAA outage or pre-resolution `useSpaceWeather()` hydration.
+
+### Documentation
+
+- **Coherence data-source audit** (`docs/2026-05-07-coherence-data-sources.md`) — verdict: ✅ single source of truth. All three coherence fields (`baseCoherence`, `positiveDailyDelta`, `displayedCoherence`) flow `astro_profiles.astro_json.fusion.harmony_index` + NOAA solar_pressure → `computeActiveImpacts` (server.mjs:2151) → `POST /api/impact/active` → `useActiveImpacts` hook → `Dashboard.tsx:269` → `DailyChartHero`. No parallel client computation. **Surfaced sharp edge:** the Zod schema validates each field independently as `[0,100]` integers but does NOT enforce the `displayed === base + delta` invariant — a future server regression would render an incoherent ring with no runtime error, caught only by the contract test.
+- **`/api/impact/active` contract documented** (`src/hooks/useActiveImpacts.ts`) — comment at the fetch callsite explains the empty `{}` body is intentional: server resolves `req.userId` via `requireUserAuth`, loads `astro_profiles` server-side, computes impacts without client input. Reference: `server.mjs:2198`.
+- **Vertiefen-button is fallback-agnostic** (`src/components/Dashboard.tsx`) — comment at the `onOpenDayModal` callsite documents that the `dailyEnabled` gate is independent of `dailyData` presence by design. Fallback data is a valid basis for opening the detail modal; the modal itself handles fallback-aware rendering.
+
+### Tests
+
+- **2 source-level guard tests** (`src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx`) — `SS3D-NO-DATA-001/002` prevent re-introduction of `data-mesh-role` / `data-tint` on R3F nodes.
+- **3 cache-poisoning regression tests** (`server/__tests__/experience-daily-no-cache-poisoning.test.mjs`) — `EDF-NCP-001` (real AI cached), `EDF-NCP-002` (fallback returned but NOT cached), `EDF-NCP-003` (consecutive failed-AI calls both retry the pipeline — closes the symptom directly).
+- **3 fallback-indicator tests** (`src/__tests__/daily-chart-hero-fallback-label.test.tsx`) — `DCH-FB-001/002/003` covering visible-when-fallback, hidden-when-real, hidden-when-impuls-empty.
+- **3 driver-dash tests** (`src/__tests__/daily-chart-hero-driver-dashes.test.tsx`) — `DCH-DASH-001/002/003` covering happy path, single-null Kp, all-null degenerate state.
+- Full suite: **2288/2288 passing** (was 2280/2280 pre-PR; net +11 = +2 guard +3 cache +3 indicator +3 dash − 0 from the 3 deleted obsolete tests counted in the +14 new). 245 test files. `tsc --noEmit` clean. `npm run build` succeeds in 10.35s.
+
+### Notes
+
+- Implementation plan: `docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md` (PR 1 = HOTFIX-A + HOTFIX-B + Phase D + Phase 4; PR 2 = Phase 2 + 3 + 5; PR 3 = Phase T, gated on aphorism approvals).
+- The plan's HOTFIX-B was authored before `server/ai-router.mjs` landed — the live investigation surfaced that the original fallback + 24h cache were already in place, and the actual symptom was the cache-poisoning narrowing described above. Plan kept for traceability; implementation was redirected.
+- Pending follow-ups (not blocking PR 1): (a) add a runtime invariant check for `displayed === base + delta` on `/api/impact/active` responses to harden the coherence contract surfaced by the audit; (b) the Driver-Strip TS types claim `kpIndex: number` (non-nullable) but the user-reported NaN/undefined symptom proves an upstream cast lies somewhere — worth tracing.
+
 ## [Unreleased] - 2026-05-07 — Dashboard CTA Consolidation (Phases A–F complete)
 
 ### Features

--- a/docs/2026-05-07-coherence-data-sources.md
+++ b/docs/2026-05-07-coherence-data-sources.md
@@ -1,0 +1,126 @@
+# Coherence data sources — audit (TASK-4.2)
+
+**Date:** 2026-05-07
+**Branch:** 2026-05-07-dashboard-stability-hotfixes
+**HEAD at start of audit:** `40d3901`
+**Scope:** Trace `baseCoherence`, `positiveDailyDelta`, `displayedCoherence` from rendering site to source.
+**Method:** Read-only — no source files modified.
+
+---
+
+## Field-by-field chain
+
+### `baseCoherence`
+
+- **Render:** `src/components/dashboard/DailyChartHero.tsx:122` (numeric label inside ring) and `:304` (passed to `SplitCoherenceRing`)
+  - Inner consumer: `SplitCoherenceRing` at `:73, :78, :85` (drives the gold baseline arc via `baseOffset`)
+- **Local fallback:** `DailyChartHero.tsx:231` — `const base = baseCoherence ?? displayed;` (defaults to displayed when base is null but displayed is present — never observed in practice; server emits both together or both null)
+- **Pass-through:** `src/components/Dashboard.tsx:378` (`baseCoherence={impactBaseCoherence}`)
+- **Dashboard variable:** `Dashboard.tsx:269` — destructured from `useActiveImpacts()` as `impactBaseCoherence`
+- **Hook:** `src/hooks/useActiveImpacts.ts:25` (interface), `:69` / `:83` / `:96` / `:132` (state assignments) — returns `baseCoherence: number | null`, sourced from `parsed.data.base_coherence ?? null`
+- **Schema:** `src/lib/schemas/active-impacts.ts:30` — `base_coherence: z.number().min(0).max(100).optional()`
+- **Server endpoint:** `POST /api/impact/active` — handler at `server.mjs:2198`
+- **Server source:** `server.mjs:2151–2153` — computed locally on the Express server:
+  ```
+  baseCoherence = hasFusionData
+    ? Math.min(100, Math.max(0, Math.round(baseHarmony * 100)))
+    : null
+  ```
+  where `baseHarmony = profile.astro_json?.fusion?.harmony_index?.harmony_index` (0–1 float from FuFirE `/calculate/fusion`, persisted into Supabase `astro_profiles.astro_json`). When `fusion.harmony_index.harmony_index` is missing on the profile, `server.mjs:2104–2143` runs a **self-heal**: live-call FuFirE `/calculate/fusion` (via `fetchFusionForBirth`) and persist the result into `astro_json` fire-and-forget. If self-heal also fails, `hasFusionData = false` and `baseCoherence` becomes `null` (drives the "Derzeit nicht verfügbar" UI branch at `DailyChartHero.tsx:254`).
+
+### `positiveDailyDelta`
+
+- **Render:** `DailyChartHero.tsx:129` (`+{positiveDailyDelta}` label) and `:305` (passed to `SplitCoherenceRing` as `positiveDailyDelta`)
+  - Inner consumer: `SplitCoherenceRing` at `:79, :95, :124` — gates the lighter delta-overlay arc behind `positiveDailyDelta > 0`
+- **Local fallback:** `DailyChartHero.tsx:232` — `const delta = positiveDailyDelta ?? 0;`
+- **Pass-through:** `Dashboard.tsx:379` (`positiveDailyDelta={impactPositiveDailyDelta}`)
+- **Dashboard variable:** `Dashboard.tsx:270` — destructured from `useActiveImpacts()` as `impactPositiveDailyDelta`
+- **Hook:** `useActiveImpacts.ts:26, :70, :84, :97, :133` — returns `positiveDailyDelta: number | null`, sourced from `parsed.data.positive_daily_delta ?? null`
+- **Schema:** `active-impacts.ts:31` — `positive_daily_delta: z.number().min(0).max(100).optional()`
+- **Server endpoint:** `POST /api/impact/active` (same handler)
+- **Server source:** `server.mjs:2154–2158` — computed as a clamped solar-pressure-weighted activation:
+  ```
+  solarDelta = hasFusionData
+    ? Math.min(100 - baseCoherence, Math.max(0, Math.round(solarPressure * sWeight * 100)))
+    : null
+  positiveDailyDelta = solarDelta
+  ```
+  where `solarPressure = spaceWeatherCache?.payload?.solar_pressure_score ?? 0` (NOAA SWPC aggregate from the 5-min `extendedSpaceWeatherCache`) and `sWeight = process.env.HARMONY_INDEX_SOLAR_WEIGHT ?? 0.35`. The `Math.min(100 - baseCoherence, …)` clamp is what guarantees `displayed_coherence ≤ 100`.
+
+### `displayedCoherence`
+
+- **Render:** `DailyChartHero.tsx:122` (`{displayedCoherence}` — the big number in the centre of the ring) and `:306` (passed to `SplitCoherenceRing` as `displayedCoherence`)
+  - Inner consumer: `SplitCoherenceRing` at `:80, :86` — drives the lighter delta-overlay arc via `deltaOffset = circumference * (1 - displayedCoherence / 100)` (which fills _to_ the displayed total, not just the delta segment, then renders behind the gold base arc)
+- **Local fallback:** `DailyChartHero.tsx:230` — `const displayed = displayedCoherence ?? (baseCoherence ?? 0);`
+- **Unavailable gate:** `DailyChartHero.tsx:254` — `const isUnavailable = displayedCoherence == null && baseCoherence == null;`
+- **Pass-through:** `Dashboard.tsx:380` (`displayedCoherence={impactDisplayedCoherence}`)
+- **Dashboard variable:** `Dashboard.tsx:271` — destructured from `useActiveImpacts()` as `impactDisplayedCoherence`
+- **Hook:** `useActiveImpacts.ts:27, :71, :85, :98, :134` — returns `displayedCoherence: number | null`, sourced from `parsed.data.displayed_coherence ?? null`
+- **Schema:** `active-impacts.ts:32` — `displayed_coherence: z.number().min(0).max(100).optional()`
+- **Server endpoint:** `POST /api/impact/active` (same handler)
+- **Server source:** `server.mjs:2157` — `displayedCoherence = hasFusionData ? baseCoherence + solarDelta : null;`
+  Computed server-side as `baseCoherence + positiveDailyDelta`. **Not** independently sourced — the server simply pre-adds the two siblings before sending the response so the client never has to.
+
+---
+
+## Single source of truth — verdict
+
+**✅ Single source.** All three values flow through exactly one chain:
+
+```
+Supabase astro_profiles.astro_json.fusion.harmony_index.harmony_index   (natal harmony, 0–1)
+                            +
+NOAA SWPC solar_pressure_score (via extendedSpaceWeatherCache)
+                            ↓
+     server.mjs `computeActiveImpacts` (lines 2151–2158, single block)
+                            ↓
+            POST /api/impact/active (ACTIVE_IMPACTS_v1 schema)
+                            ↓
+            useActiveImpacts() — sessionStorage cache, 15-min TTL
+                            ↓
+            Dashboard.tsx → DailyChartHero → SplitCoherenceRing
+```
+
+There is no parallel client-side computation, no fallback path that derives any of the three fields differently, and no second hook that produces fields with the same names. The only client-side arithmetic is the null-coalesce defaults at `DailyChartHero.tsx:230–232`, which only kick in if the server returns one field but not the others (currently impossible — server always emits all three together or all three null).
+
+`displayedCoherence` being `baseCoherence + positiveDailyDelta` is **structural, not divergent**: the addition happens once on the server (`server.mjs:2157`), the client trusts it. The schema even allows the three fields to be independent `0–100` integers — it does not enforce the additive invariant. That invariant is asserted only by the contract test `src/__tests__/contract-impact.test.ts:306–333` and by the production server code path. A mis-implementation in a future server version that broke `displayed = base + delta` would not be caught at runtime by the Zod schema.
+
+`harmony_index` (a separate top-level field at `server.mjs:2160–2162`) is a backward-compat scalar that defaults to `displayedCoherence` when fusion data is present, and falls back to a different blended formula when it isn't. It is unrelated to the three coherence fields audited here — `DailyChartHero` does not consume it. (`Dashboard.tsx:268` does destructure `harmonyIndex: impactHarmonyIndex` from the same hook, but only uses it at `:377` to gate the loading state.)
+
+---
+
+## Findings
+
+### F1 — Schema does not enforce the additive invariant
+
+**What:** `ActiveImpactsSchema` validates each of `base_coherence`, `positive_daily_delta`, `displayed_coherence` independently as `[0, 100]` integers. Nothing rejects a payload where `displayed != base + delta`.
+
+**Why it might matter:** If a future server change (or a stub/mock in tests) emits inconsistent values, the client will render a ring whose gold baseline arc and total displayed value disagree visually — base could be 80 with delta 5 but displayed shown as 30, and the ring would look broken without any error logged. The Zod safeParse at `useActiveImpacts.ts:120` would happily accept it.
+
+**Suggested follow-up:** Add a `z.refine` to `ActiveImpactsSchema` enforcing `displayed_coherence === base_coherence + positive_daily_delta` when all three are present. Cost: ~3 lines of code, breaks no current production payloads (server always satisfies the invariant).
+
+### F2 — Server-side null contract is implicit
+
+**What:** When `hasFusionData = false`, the server emits `base_coherence = null`, `positive_daily_delta = null`, `displayed_coherence = null` (server.mjs:2151–2157). The schema marks all three as `.optional()` (interpreted as "may be omitted"), but the server actually sends explicit nulls.
+
+**Why it might matter:** Zod's `.optional()` permits `undefined`, not `null`. The current `safeParse` succeeds because the JSON parse turns `null` into `null`, and the schema treats absent (no key) and `null` (key with null value) as both passing the optional check — but only because the schema is `z.number().min(0).max(100).optional()` _without_ `.nullable()`. **Verified at `contract-impact.test.ts:117–134`**: the test reads `parsed.base_coherence` after passing a payload without those fields (line 130), which confirms the optional-as-missing interpretation. The test does **not** cover the `null`-valued case the server actually emits. This is mostly fine in practice (`useActiveImpacts.ts:69` writes `cached?.base_coherence ?? null` so undefined/null both collapse to null), but a stricter Zod could break here.
+
+**Suggested follow-up:** Either tighten the server to omit the keys when fusion is absent (cheaper), or change the schema to `.nullable().optional()` to match what the server emits (more honest). Either way, add a contract test for the null-fusion case.
+
+### F3 — `harmonyIndex` and `displayed_coherence` overlap
+
+**What:** Server emits both `harmony_index` (top-level, always a number) and `displayed_coherence` (optional). When fusion data is present, they hold the same value (`server.mjs:2160` — `displayedCoherence ?? …`). When fusion data is absent, `harmony_index` falls back to a different formula (`baseHarmony * 0.65 + solarPressure * sWeight`, with `baseHarmony = 0.5`), while `displayed_coherence` is null.
+
+**Why it might matter:** Two consumers reading "the coherence" from the same response can get different answers in the unavailable state. `DailyChartHero` consumes the split fields and renders "Derzeit nicht verfügbar"; any other consumer reading `harmony_index` directly would get a synthetic 50 + solar-modulation value that misrepresents the user's actual signal absence. No such second consumer exists today (verified by grep — only `Dashboard.tsx:268` destructures `harmonyIndex` from the hook, and only uses it at line 377 to gate the loading state, not to display a number).
+
+**Suggested follow-up:** Document the contract that `harmony_index` is a legacy backward-compat field and new consumers should read `displayed_coherence` (if present) or render an unavailable state. Consider deprecating `harmony_index` once no consumer reads it as a displayed number. Out of scope for the current sprint.
+
+---
+
+## Recommendations
+
+These are suggestions for a future sprint — not decisions:
+
+- **Add Zod refinement for the additive invariant** (F1). Lowest-effort hardening; would catch any future server regression at the runtime contract boundary instead of at the visual layer.
+- **Decide between explicit-null and key-omission for fusion-absent state** (F2), then align server, schema, and contract tests. Currently the three sources of truth (server emits null, schema says optional, hook coalesces both) all happen to agree, but the alignment is accidental rather than designed.
+- **No action required for the verdict itself.** The single-source-of-truth structure is clean. The three fields are computed in one block, on one server, from one Supabase row plus one cached NOAA payload. No client-side recomputation, no parallel hook, no divergent fallback.

--- a/docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md
+++ b/docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md
@@ -1,0 +1,1396 @@
+# Dashboard Flow + Daily Pulse + 3D Signatur + Tagespuls Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stabilize the Dashboard, surface real-data Daily Pulse + the implemented 3D Signatur, and lay the foundation for the new Tagespuls (aphorism + Rat-der-sechs) architecture without changing astrological formulas, scoring, or payment plumbing.
+
+**Architecture:** Mostly verification + small UX patches over the existing component tree. Two new hotfixes (R3F crash on `/signatur`, Daily-Provider resilience). The Tagespuls neu-architecture (Phase T) is fully scaffolded in `apps/tagespuls_package/` and behind a feature flag — coexists with `useFirstRunDaily` rather than replacing it.
+
+**Tech Stack:** React 19 + Vite + Tailwind v4, react-three-fiber/three.js, Supabase (Postgres + Edge Functions), Express server proxy, Vitest + @testing-library/react.
+
+---
+
+## Reconciliation against the brief — what is already done
+
+The brief was written before the in-flight CTA consolidation work. The current branch state (verified 2026-05-07):
+
+| Brief task | Status in code | Where |
+|---|---|---|
+| TASK-1.1 isTourStepVisible bug | ✅ **Already fixed** — extracted to `useDashboardTour.ts:117–124` with correct `'done' → false` semantics | `src/hooks/useDashboardTour.ts` |
+| TASK-1.2 CTA Inventory | ✅ **Done** in unmerged branch `2026-05-07-dashboard-cta-consolidation` | `docs/upgrade-cta-inventory-2026-05-07.md` |
+| TASK-1.3 Single primary CTA | ✅ **Done** in same branch (PremiumGate info-only, AgentSection lock-only, AgentFloatingWidget hidden for free on `/`, nav-locks via hook) | 11 commits `5c3f1fa..a4fd526` |
+| TASK-1.4 Checkout error UX + analytics | ✅ **Mostly done** in same branch via `useUpgradeCheckout` hook (6 disambiguated error states, in-flight guard, redirect, 9 analytics events) | `src/hooks/useUpgradeCheckout.ts` |
+| TASK-D1 profileIncomplete prop | ✅ Already done | `src/components/dashboard/DailyChartHero.tsx:63–65, 222–224` |
+| TASK-D3 delivery-window guard comment | ✅ Already done | `src/hooks/useFirstRunDaily.ts:128–137` |
+
+**Action**: this plan does NOT redo TASK-1.x; it assumes the CTA branch will be merged before execution begins. If the merge is rejected, TASK-1.x re-inclusion is a separate decision. The brief's TASK-1.4 error taxonomy maps onto the hook's existing 6 keys with this correspondence:
+
+| Brief error label | Hook `UpgradeCheckoutError` |
+|---|---|
+| "Bitte zuerst anmelden." (no user) | `auth_required` |
+| "Sitzung abgelaufen." (401) | `auth_required` (same key — server only differentiates via `code: AUTH_REQUIRED` vs `AUTH_INVALID`) |
+| "Kein Zugriff." (403) | `already_premium` (server's only 403 path today) |
+| "Zahlung derzeit nicht verfügbar." (503) | `stripe_unavailable` |
+| "Unerwartete Antwort." (200 no url) | `unknown` |
+| "Verbindungsproblem." (network) | `network` |
+
+Acceptable as-is; if the brief's exact label split is required, a follow-up adds 7th error key `auth_expired` distinct from `auth_required`. NOT part of this plan.
+
+---
+
+## New tasks not in the brief (added 2026-05-07 after live investigation)
+
+| ID | Why | Priority |
+|---|---|---|
+| HOTFIX-A | `/signatur` page crashes hard with R3F error `Cannot set "data-tint"`. ErrorBoundary catches it; user sees "Etwas ist schiefgelaufen" instead of the sphere. **This is the actual root cause for "Signatur kaputt"** — not data flow. | P0 — must ship before Phase 2 |
+| HOTFIX-B | `/api/experience/daily` proxies to Gemini, Gemini free-tier returns 429 `RESOURCE_EXHAUSTED` on every call (limit: 0 req/day). Client falls back to deterministic `buildFallbackDaily()` text. Make this provider failure resilient via OpenRouter or 24h cache. | P1 |
+
+---
+
+## Phase 0 — Baseline
+
+**Run before any task. No task starts without baseline.**
+
+```bash
+cd /Users/benjaminpoersch/Projects/codebase/Bazodiac-WebApp/Astro-Noctum
+git status                      # working tree must be clean
+git log --oneline -3            # know which branch + commits you're starting from
+npx vitest run 2>&1 | tail -5   # full suite must be green
+npx tsc --noEmit && echo OK     # tsc must be clean
+npm run build 2>&1 | tail -5    # build must succeed
+```
+
+Expected baseline: **2280/2280 tests passing**, tsc clean, vite build OK in ~6s.
+
+If any of the three fail before changes — STOP, report the failure, do not proceed. Existing failures must be triaged separately.
+
+---
+
+## HOTFIX-A — R3F data-* removal on `<mesh>` elements
+
+### Task A1: Remove `data-mesh-role` and `data-tint` from R3F nodes in SignatureSphere3D
+
+**Files:**
+- Modify: `src/components/signatur-3d/SignatureSphere3D.tsx:373, 390-391, 411`
+
+**Why:** react-three-fiber treats unknown JSX props on `<mesh>` / `<group>` as Three.js property setters. `data-tint="gold"` triggers `Cannot set "data-tint"` in `applyProps` and crashes the entire R3F tree. The data-* attributes were intended as CSS/dev selectors but are non-functional on Three.Object3D.
+
+**Step 1: Write the failing test**
+
+```ts
+// src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('SignatureSphere3D — no data-* on R3F nodes (HOTFIX-A)', () => {
+  it('SS3D-NO-DATA-001: source has no data-mesh-role attribute', () => {
+    const src = readFileSync(resolve(__dirname, '../SignatureSphere3D.tsx'), 'utf8');
+    expect(src).not.toMatch(/data-mesh-role/);
+  });
+  it('SS3D-NO-DATA-002: source has no data-tint attribute', () => {
+    const src = readFileSync(resolve(__dirname, '../SignatureSphere3D.tsx'), 'utf8');
+    expect(src).not.toMatch(/data-tint/);
+  });
+});
+```
+
+(Source-level guard rather than mounting Canvas — R3F is not testable in jsdom without a heavy WebGL mock, and the bug is purely structural.)
+
+**Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx
+```
+
+Expected: FAIL with `Expected source not to match /data-mesh-role/` and same for `/data-tint/`.
+
+**Step 3: Remove the data-* props from `SignatureSphere3D.tsx`**
+
+Lines 373, 390, 391, 411 — delete just those JSX attribute lines. The visual output is unchanged (data-* are non-functional on R3F nodes).
+
+If the props were intended to be discoverable in a CSS-based dev tool, replace with `userData={{ meshRole: '<value>', tint: '<value>' }}` — that IS the supported R3F way. For this hotfix, simple removal is enough; userData migration can be a follow-up.
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx
+npx vitest run    # full suite must stay green (was 2280)
+npx tsc --noEmit
+```
+
+Expected: 2 + 2280 = 2282/2282 passing, tsc clean.
+
+**Step 5: Live smoke test**
+
+Start dev server (Vite + Express). Open `http://localhost:3000/signatur` in browser. Expected: 3D sphere renders, no "Etwas ist schiefgelaufen" overlay, no R3F errors in console.
+
+```bash
+# Browser console — install error trap before navigating then check
+# (See docs in this plan's investigation log if you need the harness recipe)
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/components/signatur-3d/SignatureSphere3D.tsx \
+        src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(signatur-3d): remove data-* props from R3F mesh nodes
+
+R3F's applyProps treats unknown JSX attributes on <mesh>/<group>
+as Three.js property setters. `data-tint="gold"` and the three
+`data-mesh-role` attributes (lines 373, 390-391, 411 from commit
+33a1119) triggered:
+
+  Uncaught Error: R3F: Cannot set "data-tint".
+  Ensure it is an object before setting "tint".
+
+ErrorBoundary caught it and the entire /signatur page rendered as
+"Etwas ist schiefgelaufen" instead of the Chladni sphere. This is
+the actual root cause of "Signatur kaputt" — not the FuFirE 401
+fallback.
+
+The data-* attrs were non-functional on R3F nodes (CSS selectors
+don't reach Three.Object3D). Removed entirely; if dev-time
+discoverability is needed later, userData={{...}} is the R3F-
+supported equivalent.
+
+Source-level guard tests prevent re-introduction.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## HOTFIX-B — Daily provider resilience
+
+### Task B1: Server-side OpenRouter fallback when Gemini returns 429 on /api/experience/daily
+
+**Files:**
+- Modify: `server.mjs` — find the daily handler block (around line 2568) + the AI router quota path (search for `[ai-router] gemini-direct quota/429`)
+
+**Why:** Gemini free-tier daily limit is 0 req/day for `gemini-2.0-flash`. Currently the AI router falls through to nothing when quota is exhausted — the response cascades into `[experience/daily] Error: 429` and the client uses `buildFallbackDaily()` (deterministic generic German text). User sees the same "Heute fließt deine Energie ruhig..." every day.
+
+The server already has `OPENROUTER_API_KEY` plumbing (env var documented). Wire it as the AI-router's fallback specifically for the daily endpoint when the primary provider returns 429.
+
+**Step 1: Inspect the AI router**
+
+```bash
+grep -n "gemini-direct\|openrouter\|ai-router" server.mjs | head -30
+```
+
+Identify the quota-fallthrough path. There's likely a `routeAI()` or similar helper that picks the provider.
+
+**Step 2: Write integration tests for the fallback path**
+
+```js
+// server/__tests__/experience-daily-fallback.test.mjs
+// Mock global.fetch: first call (Gemini) returns 429, second call (OpenRouter) returns valid completion.
+// Hit /api/experience/daily with a valid body, assert response is valid (not 429, has fusion.synthesis).
+```
+
+(Reuse the test harness pattern in existing `server/__tests__/*.test.mjs`.)
+
+**Step 3: Implement provider fallback**
+
+```js
+// In the daily handler (around the AI call):
+async function callDailyAi(prompt) {
+  try {
+    return await callGemini(prompt);
+  } catch (err) {
+    if (err.status === 429 && process.env.OPENROUTER_API_KEY) {
+      console.log('[experience/daily] Gemini 429 → OpenRouter fallback');
+      return await callOpenRouter(prompt);
+    }
+    throw err;
+  }
+}
+```
+
+Adapt to the actual existing AI router shape — don't add a new abstraction layer. If `callOpenRouter()` doesn't exist, this is out of scope and we fall back to step 4 (cache-only).
+
+**Step 4: Add 24h response cache for daily**
+
+```js
+// In daily handler — before AI call:
+const cacheKey = `daily:${userId}:${targetDate}:${lang}`;
+const cached = await getCachedDaily(cacheKey);
+if (cached) return res.json(cached);
+
+// After successful AI call:
+await setCachedDaily(cacheKey, response, 24 * 3600);
+```
+
+The 24h cache is the pragmatic bottom line — even if both providers fail, every user only hits AI once per day per locale. The existing daily endpoint already has a caching helper around line 2600 (`cacheKeyD = ` daily:...) — verify and extend.
+
+**Step 5: Run tests**
+
+```bash
+npx vitest run server/__tests__/experience-daily-fallback.test.mjs
+npx vitest run    # full suite stable
+```
+
+**Step 6: Verify live**
+
+```bash
+# Restart Express, hit /api/experience/daily, check logs:
+tail -f /tmp/express-dev.log | grep -E "OpenRouter fallback|429|cache hit"
+```
+
+**Step 7: Commit**
+
+```bash
+git add server.mjs server/__tests__/experience-daily-fallback.test.mjs
+git commit -m "$(cat <<'EOF'
+fix(experience/daily): OpenRouter fallback + 24h cache when Gemini 429
+
+Gemini free-tier limit (0 req/day) cascaded into the client
+fallback every single call. Result: 100% of users see the same
+deterministic German text as their "Tagesimpuls" — never a real
+horoscope. Two layers:
+
+1. Provider fallback — when Gemini returns 429 and
+   OPENROUTER_API_KEY is set, retry once via OpenRouter. Same
+   prompt, same response shape. Logs "Gemini 429 → OpenRouter
+   fallback" so quota events stay visible.
+
+2. 24h response cache keyed by user+date+locale. Even if both
+   providers fail, the user only triggers AI once per day. The
+   existing cacheKeyD around server.mjs:2600 is extended to wrap
+   the response, not just the prompt input.
+
+Closes the "Tagesimpuls fehlt" symptom from the user-reported
+2026-05-07 regression triage.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase D — Daily Pulse Visibility
+
+### Task D2: Fallback-Origin sichtbar machen
+
+**Files:**
+- Modify: `src/components/dashboard/DailyChartHero.tsx` (add prop + render)
+- Modify: `src/components/Dashboard.tsx` (derive + pass)
+- Test: `src/__tests__/daily-chart-hero-fallback-label.test.tsx`
+
+**Why:** When `buildFallbackDaily()` fires (FuFirE/Gemini down), `meta.engine_version` is set to `'v1-local-fallback'` but the user sees the same UI as a real response. They have no way to know the content is generic.
+
+**Step 1: Write the failing test**
+
+```tsx
+// src/__tests__/daily-chart-hero-fallback-label.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/src/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de' as const, t: (k: string) => k }),
+}));
+
+import { DailyChartHero } from '@/src/components/dashboard/DailyChartHero';
+
+const baseProps = {
+  loading: false,
+  baseCoherence: 60,
+  positiveDailyDelta: 0,
+  displayedCoherence: 60,
+  spaceWeather: { kpIndex: 0, solarPressureScore: 0.18, geomagnetic: 'quiet' as const, solar: 'quiet' as const, ringModulation: 1.0 },
+  transitEvents: [],
+  dayMode: 'pulse' as const,
+  birthSign: 'Aries',
+  impulsText: 'Generic fallback text.',
+  profileIncomplete: false,
+  onCompleteProfile: () => {},
+  onOpenDayModal: () => {},
+};
+
+describe('DailyChartHero fallback indicator (TASK-D2)', () => {
+  it('DCH-FB-001: shows fallback indicator when isFallback=true and impuls is present', () => {
+    render(<DailyChartHero {...baseProps} isFallback={true} />);
+    expect(screen.getByTestId('fallback-indicator')).toBeInTheDocument();
+    expect(screen.getByText(/Heute nicht verfügbar/i)).toBeInTheDocument();
+  });
+  it('DCH-FB-002: NO indicator when isFallback=false', () => {
+    render(<DailyChartHero {...baseProps} isFallback={false} />);
+    expect(screen.queryByTestId('fallback-indicator')).not.toBeInTheDocument();
+  });
+  it('DCH-FB-003: NO indicator when isFallback=true but impulsText empty (profile-incomplete already shows different state)', () => {
+    render(<DailyChartHero {...baseProps} isFallback={true} impulsText={undefined} profileIncomplete={true} />);
+    expect(screen.queryByTestId('fallback-indicator')).not.toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/__tests__/daily-chart-hero-fallback-label.test.tsx
+```
+
+Expected: FAIL — prop `isFallback` doesn't exist yet.
+
+**Step 3: Add the prop and render in DailyChartHero**
+
+```tsx
+// src/components/dashboard/DailyChartHero.tsx
+// In Props interface, add:
+isFallback?: boolean;
+
+// In the component params destructure:
+isFallback = false,
+
+// In Section D (after the impulsText paragraph):
+{isFallback && hasImpuls && (
+  <p
+    className="text-[9px] text-center mt-2"
+    style={{ color: 'var(--tile-text-secondary)', opacity: 0.4 }}
+    data-testid="fallback-indicator"
+  >
+    {isDe ? '↻ Heute nicht verfügbar — generischer Inhalt' : '↻ Unavailable today — generic content'}
+  </p>
+)}
+```
+
+**Step 4: Pass `isFallback` from Dashboard.tsx**
+
+```tsx
+// src/components/Dashboard.tsx — at the DailyChartHero mount (around line 376)
+isFallback={dailyData?.meta?.engine_version === 'v1-local-fallback'}
+```
+
+**Step 5: Verify**
+
+```bash
+npx vitest run src/__tests__/daily-chart-hero-fallback-label.test.tsx
+npx vitest run    # full suite stable
+npx tsc --noEmit
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/components/dashboard/DailyChartHero.tsx \
+        src/components/Dashboard.tsx \
+        src/__tests__/daily-chart-hero-fallback-label.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(dashboard): visible fallback indicator on DailyChartHero (TASK-D2)
+
+When buildFallbackDaily() fires due to FuFirE/Gemini outage, the
+client used to render the generic deterministic text as if it were
+the real horoscope. New optional `isFallback` prop on
+DailyChartHero renders a 9px-opacity-40% line under the impuls
+paragraph: "↻ Heute nicht verfügbar — generischer Inhalt"
+(DE) / "↻ Unavailable today — generic content" (EN).
+
+Dashboard.tsx derives the flag from
+`dailyData?.meta?.engine_version === 'v1-local-fallback'`. Real API
+response → no label. Profile-incomplete → no label (different state
+already handled).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task D4: Verify "vertiefen →" path with fallback data
+
+**Files:**
+- Modify: `src/components/Dashboard.tsx` (comment only)
+
+**Why:** Verify there's no codepath where `dailyData !== null` (fallback fired) but `onOpenDayModal` is omitted. Brief notes the current `dailyEnabled` guard is independent of `dailyData` — confirm and document.
+
+**Step 1: Read the current callsite**
+
+```bash
+grep -n "onOpenDayModal\|dailyEnabled" src/components/Dashboard.tsx | head -5
+```
+
+Expected: `onOpenDayModal={dailyEnabled ? () => setIsDayModalOpen(true) : undefined}` — gated only on the feature flag.
+
+**Step 2: Add documentation comment above that line**
+
+```tsx
+// onOpenDayModal is intentionally passed regardless of dailyData
+// presence. Fallback data is a valid basis for opening the detail
+// modal; the modal itself handles fallback-aware rendering.
+onOpenDayModal={dailyEnabled ? () => setIsDayModalOpen(true) : undefined}
+```
+
+**Step 3: Verify** — `tsc --noEmit` clean. No test needed; this is purely documentation.
+
+**Step 4: Commit**
+
+```bash
+git add src/components/Dashboard.tsx
+git commit -m "docs(dashboard): document vertiefen-button is fallback-agnostic (TASK-D4)"
+```
+
+---
+
+## Phase 2 — 3D Signatur Sichtbarkeit
+
+### Task 2.1: Verify chladniParams pipeline + Wu-Xing DE/EN drift risk
+
+**Files:**
+- Read: `src/lib/cymatics/bazi-to-chladni.ts`
+- Read: `src/pages/SignaturPage.tsx` (where SignaturRenderer is mounted, line ~325)
+- Read: `src/components/signatur-renderer/SignaturRenderer.tsx`
+- Output: `docs/2026-05-07-signatur-3d-pipeline-audit.md`
+
+**Why:** The brief reports "User findet die Kugel nicht" — but the live investigation showed the actual cause is the R3F crash (HOTFIX-A). After A1 lands, the secondary question is: does `chladniParams` get computed for typical profiles, or does the page fall back to `<CymaticsFallback/>` (Water default) for everyone?
+
+**Step 1: Inspect the BaZi → Chladni pipeline**
+
+```bash
+grep -n "baziToChladni\|computeChladni\|ChladniParams" src/lib/cymatics/bazi-to-chladni.ts | head -10
+grep -n "chladniParams" src/pages/SignaturPage.tsx | head -5
+```
+
+Read the function signature and what it requires. Check if it depends on `apiData?.bazi?.dominant_element` (English key) vs `dominantes_element` (German key — known DE/EN drift bug).
+
+**Step 2: Live trace via dev server**
+
+```bash
+# With dev servers running, open /signatur as the test user
+# In browser console:
+window.__chladniDebug = (params) => console.log('chladniParams:', JSON.stringify(params));
+# Then navigate to /signatur and watch console.
+```
+
+Or — read `SignaturPage.tsx` lines around 320 to see how `chladniParams` is computed, and instrument `[chladni]` log lines in `bazi-to-chladni.ts` temporarily for one verification cycle.
+
+**Step 3: Document findings in `docs/2026-05-07-signatur-3d-pipeline-audit.md`**
+
+- What does `baziToChladni()` need? What does it produce when the input has the DE-keyed Wu-Xing dominant element vs EN?
+- What % of production users have the prerequisite data? (Check Supabase: `select count(*) from astro_profiles where wuxing_data is not null`)
+- If DE/EN drift causes blank `chladniParams` for some users → document the failure rate. Recommend separate fix-track (per the brief's Hinweis #8).
+
+**Step 4: Commit**
+
+```bash
+git add docs/2026-05-07-signatur-3d-pipeline-audit.md
+git commit -m "docs(signatur-3d): pipeline audit — chladniParams data flow + DE/EN risk"
+```
+
+---
+
+### Task 2.2: SignaturAnchorCard on the Dashboard (Option B)
+
+**Files:**
+- Create: `src/components/dashboard/SignaturAnchorCard.tsx`
+- Create: `src/__tests__/signatur-anchor-card.test.tsx`
+- Modify: `src/components/Dashboard.tsx` (mount SignaturAnchorCard in the new hierarchy slot)
+
+**Why:** Anchor card with `<NatalSignaturStatic>` (or equivalent) preview + "Deine Signatur ansehen →" CTA navigating to `/signatur`. NO WebGL on the dashboard yet — performance-safe, hop into `/signatur` only when user wants to engage. Brief's Option A (embedded R3F on dashboard) is deferred until Option B is stable in prod.
+
+**Step 1: Write the failing test**
+
+```tsx
+// src/__tests__/signatur-anchor-card.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => mockNavigate }));
+vi.mock('@/src/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de' as const, t: (k: string) => k }),
+}));
+
+import { SignaturAnchorCard } from '@/src/components/dashboard/SignaturAnchorCard';
+
+describe('SignaturAnchorCard (TASK-2.2)', () => {
+  it('SAC-001: renders preview + CTA', () => {
+    render(<SignaturAnchorCard dominantElement="feuer" birthSign="Aries" />);
+    expect(screen.getByTestId('signatur-anchor-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /signatur ansehen/i })).toBeInTheDocument();
+  });
+  it('SAC-002: CTA navigates to /signatur', async () => {
+    const user = userEvent.setup();
+    render(<SignaturAnchorCard dominantElement="feuer" birthSign="Aries" />);
+    await user.click(screen.getByRole('button', { name: /signatur ansehen/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/signatur');
+  });
+  it('SAC-003: empty state when neither prop is provided', () => {
+    render(<SignaturAnchorCard />);
+    // Render an explanatory empty state, not a broken preview
+    expect(screen.getByTestId('signatur-anchor-card')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/__tests__/signatur-anchor-card.test.tsx
+```
+
+Expected: FAIL — component doesn't exist.
+
+**Step 3: Implement SignaturAnchorCard**
+
+```tsx
+// src/components/dashboard/SignaturAnchorCard.tsx
+import { useNavigate } from 'react-router-dom';
+import { useLanguage } from '@/src/contexts/LanguageContext';
+
+interface Props {
+  dominantElement?: string;
+  birthSign?: string;
+}
+
+export function SignaturAnchorCard({ dominantElement, birthSign }: Props) {
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+  return (
+    <section
+      className="cosmic-tile p-6 rounded-[2rem] flex items-center gap-4"
+      data-testid="signatur-anchor-card"
+    >
+      {/* Static preview placeholder. NatalSignaturStatic if available, else 1-line glyph + element. */}
+      <div className="flex-1">
+        <p className="text-xs uppercase tracking-[0.2em] text-ink/60">
+          {t('signatur.anchor.title') /* "Deine Signatur" */}
+        </p>
+        <p className="text-xs text-ink/40 mt-1">
+          {dominantElement && birthSign
+            ? `${birthSign} · ${dominantElement}`
+            : t('signatur.anchor.empty') /* "Profil unvollständig" */}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => navigate('/signatur')}
+        className="text-sm text-gold hover:text-gold/80 transition-colors"
+      >
+        {t('signatur.anchor.cta') /* "Signatur ansehen →" */}
+      </button>
+    </section>
+  );
+}
+```
+
+Add the i18n keys to `src/i18n/translations.ts` (DE+EN):
+
+```ts
+signatur: {
+  // ...existing keys
+  anchor: {
+    title: /* DE */ 'Deine Signatur' /* EN */ 'Your Signature',
+    cta: /* DE */ 'Signatur ansehen →' /* EN */ 'View signature →',
+    empty: /* DE */ 'Profil unvollständig' /* EN */ 'Profile incomplete',
+  },
+},
+```
+
+**Step 4: Run tests**
+
+```bash
+npx vitest run src/__tests__/signatur-anchor-card.test.tsx
+npx vitest run    # full suite stable
+npm run check:text-integrity
+npx tsc --noEmit
+```
+
+**Step 5: Mount in Dashboard.tsx (after DailyChartHero, before AgentSection)**
+
+```tsx
+{/* ═══ 1.5 SIGNATUR ANCHOR ══════════════════════════════════════ */}
+<motion.div {...fadeIn(0.10)}>
+  <SectionErrorBoundary name="SignaturAnchor">
+    <SignaturAnchorCard
+      dominantElement={apiData?.wuxing?.dominant_element}
+      birthSign={apiData?.western?.zodiac_sign}
+    />
+  </SectionErrorBoundary>
+</motion.div>
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/components/dashboard/SignaturAnchorCard.tsx \
+        src/__tests__/signatur-anchor-card.test.tsx \
+        src/components/Dashboard.tsx \
+        src/i18n/translations.ts
+git commit -m "$(cat <<'EOF'
+feat(dashboard): SignaturAnchorCard preview + CTA on dashboard (TASK-2.2)
+
+Free + premium users now see a static anchor on the dashboard
+linking to /signatur. Performance-safe: no WebGL on dashboard
+mount; users opt into the 3D Chladni sphere by tapping the CTA.
+
+Empty state when profile incomplete. Follows the new dashboard
+hierarchy:
+  1. DailyChartHero
+  2. SignaturAnchor          ← NEW (here)
+  3. Active Influences       (later in DailyChartHero)
+  4. Agents
+  5. Bottom upgrade card
+
+Brief Option B (preview + link). Option A (embedded R3F on
+dashboard) is deferred until B is stable in prod.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Dashboard-Informationshierarchie
+
+### Task 3.1: Section ordering — verify against brief target
+
+**Files:**
+- Modify (verify only): `src/components/Dashboard.tsx`
+- Output: `docs/2026-05-07-dashboard-hierarchy-audit.md`
+
+**Why:** The brief specifies a target hierarchy; verify the post-Phase 2 dashboard matches. After SignaturAnchorCard lands, the order should be:
+
+```
+1. DailyChartHero          — was ist heute los
+2. SignaturAnchorCard      — wer bin ich (persistent)        [Phase 2]
+3. AgentSection            — vertiefen via voice
+4. DashboardAstroSection   — Big Four (PremiumGate, info-only)
+5. DashboardInterpretationSection  — AI-Synthese (PremiumGate)
+6. DashboardTagesEnergie   — Day-Pulse details
+7. MagnetsturmKarte        — space weather card
+8. DashboardBottomUpgradeCard  — single upgrade CTA (free only)
+```
+
+**Step 1: Read current Dashboard JSX top-to-bottom and capture the order**
+
+```bash
+grep -nE "^\s*<[A-Z]|^\s*\{!isPremium" src/components/Dashboard.tsx | head -40
+```
+
+**Step 2: Document deviations from brief target in `docs/2026-05-07-dashboard-hierarchy-audit.md`**
+
+Identify:
+- Sections that are out of order
+- Sections that are missing from the brief target
+- Sections in the brief target that don't exist in code (skip if dead)
+
+**Step 3: Apply minimal reordering if needed** (no new components, just JSX block reorder)
+
+If the order is mostly right, document and skip code changes. If a clear improvement is identified, apply with one git commit.
+
+**Step 4: Commit**
+
+```bash
+git add docs/2026-05-07-dashboard-hierarchy-audit.md src/components/Dashboard.tsx
+git commit -m "refactor(dashboard): align section order with target hierarchy (TASK-3.1)"
+```
+
+---
+
+### Task 3.2: Retention metric TODOs
+
+**Files:**
+- Modify (annotate only): `src/components/Dashboard.tsx`, `src/components/dashboard/DayModeModal.tsx`, `src/components/dashboard/SignaturAnchorCard.tsx`
+
+**Why:** Brief requires `TODO(analytics):` markers at key user-action surfaces so an analytics-focused sprint can wire them up later.
+
+**Step 1: Add TODO comments**
+
+```tsx
+// Dashboard.tsx — first dashboard mount
+useEffect(() => {
+  // TODO(analytics): trackEvent('dashboard_first_interaction') on first user action
+}, []);
+
+// DayModeModal.tsx — on open
+useEffect(() => {
+  if (open) {
+    // TODO(analytics): trackEvent('daily_detail_open_rate')
+  }
+}, [open]);
+
+// SignaturAnchorCard.tsx — on CTA click
+onClick={() => {
+  // TODO(analytics): trackEvent('signatur_sphere_interaction')
+  navigate('/signatur');
+}}
+```
+
+**Step 2: Verify** — tsc clean.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/Dashboard.tsx \
+        src/components/dashboard/DayModeModal.tsx \
+        src/components/dashboard/SignaturAnchorCard.tsx
+git commit -m "chore(analytics): TODO markers for retention metrics (TASK-3.2)"
+```
+
+---
+
+## Phase 4 — Daily Chart API Cleanup
+
+### Task 4.1: /api/impact/active contract documentation
+
+**Files:**
+- Modify: `src/hooks/useActiveImpacts.ts` (comment only)
+- Read: `server.mjs` `/api/impact/active` handler
+
+**Step 1: Inspect server-side handler**
+
+```bash
+grep -n "/api/impact/active" server.mjs | head -5
+```
+
+Find the handler. Read 30 lines. Determine: does it use `req.body`, or does it resolve the user from `req.userId` (set by `requireUserAuth`)?
+
+**Step 2: Document in the hook**
+
+```ts
+// src/hooks/useActiveImpacts.ts — at the fetch call
+const res = await authedFetch('/api/impact/active', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  // Contract: server is profile-driven (resolves req.userId from session,
+  // loads astro_profiles + computes impacts server-side). Empty body is
+  // intentional — see server.mjs:<line>.
+  body: '{}',
+});
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/hooks/useActiveImpacts.ts
+git commit -m "docs(useActiveImpacts): document /api/impact/active is server-profile-driven (TASK-4.1)"
+```
+
+---
+
+### Task 4.2: DailyChartHero data sources — verify single source of truth
+
+**Files:**
+- Read: `src/components/dashboard/DailyChartHero.tsx`
+- Read: `src/hooks/useActiveImpacts.ts`
+- Read: `src/components/Dashboard.tsx`
+- Output: `docs/2026-05-07-coherence-data-sources.md`
+
+**Step 1: Trace `baseCoherence`, `positiveDailyDelta`, `displayedCoherence` upstream**
+
+```bash
+grep -nE "baseCoherence|positiveDailyDelta|displayedCoherence|impactBaseCoherence|impactPositiveDailyDelta|impactDisplayedCoherence" \
+  src/components/Dashboard.tsx src/components/dashboard/DailyChartHero.tsx src/hooks/useActiveImpacts.ts | head -20
+```
+
+**Step 2: Document the data flow**
+
+If both `useActiveImpacts` and another hook touch these fields → flag as duplication. If only `useActiveImpacts` is the source → document the contract and pass through Dashboard.
+
+**Step 3: Commit**
+
+```bash
+git add docs/2026-05-07-coherence-data-sources.md
+git commit -m "docs(daily-chart): document baseCoherence/delta/displayed data flow (TASK-4.2)"
+```
+
+---
+
+### Task 4.3: Degraded states visible — Driver-Strip dashes
+
+**Files:**
+- Modify: `src/components/dashboard/DailyChartHero.tsx` (Driver Strip block)
+- Test: Reuse `daily-chart-hero-fallback-label.test.tsx` or create dedicated
+
+**Step 1: Find the Driver Strip rendering**
+
+```bash
+grep -n "Geomagnetic\|Solar pressure\|Transit activity\|driver-strip" src/components/dashboard/DailyChartHero.tsx | head -5
+```
+
+**Step 2: Add fallback dashes when value is null/undefined**
+
+```tsx
+// Before:
+<span>{spaceWeather.kpIndex.toFixed(1)}</span>
+// After:
+<span>{spaceWeather.kpIndex != null ? spaceWeather.kpIndex.toFixed(1) : '—'}</span>
+```
+
+(Apply to all three driver values.)
+
+**Step 3: Test + commit**
+
+```bash
+npx vitest run src/__tests__/daily-chart-hero-fallback-label.test.tsx
+git add src/components/dashboard/DailyChartHero.tsx
+git commit -m "feat(daily-chart): em-dash placeholders when driver values null (TASK-4.3)"
+```
+
+---
+
+## Phase 5 — GreenOps
+
+### Task 5.1: Transit-Polling-Frequenz reduzieren
+
+**Files:**
+- Modify: `src/hooks/useSignaturSignal.ts`
+- Test: `src/__tests__/use-signatur-signal-polling.test.ts`
+
+**Step 1: Read current polling logic**
+
+```bash
+grep -n "800\|setInterval\|POLL_INTERVAL\|visibilitychange" src/hooks/useSignaturSignal.ts | head -10
+```
+
+**Step 2: Write test for visibility-aware polling**
+
+```ts
+// Mock document.visibilityState; assert poll interval is 60000ms when hidden, 15000ms when visible.
+// Mock global.fetch + assert request count over a simulated 5-minute window with hidden tab is < 6.
+```
+
+**Step 3: Implement visibility-aware polling**
+
+```ts
+const POLL_INTERVAL = 15_000;
+const HIDDEN_INTERVAL = 60_000;
+
+useEffect(() => {
+  let id: number;
+  const tick = () => {
+    fetchTransitState();
+    const interval = document.visibilityState === 'hidden' ? HIDDEN_INTERVAL : POLL_INTERVAL;
+    id = window.setTimeout(tick, interval);
+  };
+  tick();
+  const onVis = () => {
+    if (document.visibilityState === 'visible') {
+      window.clearTimeout(id);
+      tick();  // immediate refresh on focus
+    }
+  };
+  document.addEventListener('visibilitychange', onVis);
+  return () => {
+    window.clearTimeout(id);
+    document.removeEventListener('visibilitychange', onVis);
+  };
+}, [/* deps */]);
+```
+
+**Step 4: Test + commit**
+
+```bash
+npx vitest run src/__tests__/use-signatur-signal-polling.test.ts
+git add src/hooks/useSignaturSignal.ts src/__tests__/use-signatur-signal-polling.test.ts
+git commit -m "perf(signatur): visibility-aware polling, 15s active / 60s hidden (TASK-5.1)"
+```
+
+---
+
+### Task 5.2: SpaceWeather-Hook deduplizieren
+
+**Files:**
+- Modify: `src/components/dashboard/MagnetsturmKarte.tsx` (accept prop instead of calling hook)
+- Modify: `src/components/Dashboard.tsx` (pass spaceWeather prop)
+- Test: `src/__tests__/magnetsturm-karte-prop-driven.test.tsx`
+
+**Step 1: Test that MagnetsturmKarte accepts spaceWeather as prop**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MagnetsturmKarte } from '@/src/components/dashboard/MagnetsturmKarte';
+
+it('MK-PROP-001: renders from prop, no hook call', () => {
+  const sw = { kpIndex: 4, geomagnetic: 'unsettled' as const, /* ... */ };
+  render(<MagnetsturmKarte spaceWeather={sw} />);
+  expect(screen.getByText(/Kp/)).toBeInTheDocument();
+});
+```
+
+**Step 2: Refactor MagnetsturmKarte**
+
+```tsx
+interface Props { spaceWeather: SpaceWeatherState; }
+export function MagnetsturmKarte({ spaceWeather }: Props) {
+  // Remove `useSpaceWeather()` call — read from prop instead.
+  // ... same render logic ...
+}
+```
+
+**Step 3: Update Dashboard.tsx mount**
+
+```tsx
+const spaceWeather = useSpaceWeather();
+// ...
+<MagnetsturmKarte spaceWeather={spaceWeather} />
+```
+
+**Step 4: Test + commit**
+
+```bash
+npx vitest run src/__tests__/magnetsturm-karte-prop-driven.test.tsx
+git add src/components/dashboard/MagnetsturmKarte.tsx \
+        src/components/Dashboard.tsx \
+        src/__tests__/magnetsturm-karte-prop-driven.test.tsx
+git commit -m "perf(dashboard): MagnetsturmKarte is prop-driven, single SpaceWeather poller (TASK-5.2)"
+```
+
+---
+
+## Phase T — Tagespuls Neu-Architektur
+
+> ⚠️ **Phase T is GATED on TASK-T0.** Currently `aphorisms.json` is empty (0 approved out of 21 markdown files: 16 draft + 5 review). Phase T will not execute until Ben approves ≥15 aphorisms across 3 mode-tags.
+
+### Task T0: Prerequisite Gate — verify aphorisms.json non-empty
+
+**Files:**
+- Read: `apps/tagespuls_package/packages/voice/data/aphorisms.json`
+- Output: `docs/tagespuls-gate-check.txt`
+
+**Step 1: Run the gate check**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('apps/tagespuls_package/packages/voice/data/aphorisms.json'))
+modes = {t for a in d for t in a['mode_tags']}
+print(f'{len(d)} aphorisms, modes: {modes}')
+assert len(d) >= 15, 'Zu wenig approved aphorisms — Prerequisite nicht erfüllt'
+assert {'pulse','trace','spannung'} <= modes or len(d) >= 10, 'Mode-Coverage unvollständig'
+print('Gate: OK')
+" 2>&1 | tee docs/tagespuls-gate-check.txt
+```
+
+**Step 2: Decision branch**
+
+- **Gate PASS** → continue to T1.
+- **Gate FAIL** → STOP. Output `docs/tagespuls-gate-check.txt` with exit code, alert PO (Ben). The remaining T1-T7 tasks remain in this plan but are blocked.
+
+**Step 3: Commit gate result**
+
+```bash
+git add docs/tagespuls-gate-check.txt
+git commit -m "$(cat <<'EOF'
+docs(tagespuls): TASK-T0 gate check result
+
+Records the current approval state of the aphorism corpus.
+Gate threshold: ≥15 approved across pulse/trace/spannung mode-tags.
+
+Status: <PASS|FAIL>
+Approved count: <N>
+
+If FAIL: Phase T (T1-T7) is blocked until PO approval round
+flips additional aph-*.md files from `status: draft|review` to
+`status: approved`.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task T1: Supabase migration — 6 tables from packages/db/schema.sql
+
+**Files:**
+- Create: `supabase-migrations/20260507_tagespuls_tables.sql`
+- Reference: `apps/tagespuls_package/packages/db/schema.sql`
+
+**Step 1: Copy schema with adaptations**
+
+Adapt for the live Bazodiac Supabase project:
+- Use `auth.users(id)` for `user_id` foreign keys
+- Add RLS policies (service_role only — mirrors `ai_quota` lockdown pattern from the recent backend hardening sprint)
+- Match column types and constraints exactly
+
+**Step 2: Apply via Supabase MCP or CLI**
+
+```bash
+# Option A — Supabase MCP (preferred):
+# Use mcp__claude_ai_Supabase__apply_migration with name="tagespuls_tables", query=<contents>
+
+# Option B — CLI:
+psql $DATABASE_URL -f supabase-migrations/20260507_tagespuls_tables.sql
+```
+
+**Step 3: Verify**
+
+```bash
+# Via MCP: mcp__claude_ai_Supabase__list_tables
+# Or psql: \d aphorisms; \d daily_pulses; \d daily_interpretations
+```
+
+All 6 tables exist with correct columns + RLS enabled.
+
+**Step 4: Update `supabase-schema.sql` to keep schema-file/migration parity**
+
+Per memory `feedback_schema_migration_alignment.md`: both files must describe the same end state.
+
+**Step 5: Commit**
+
+```bash
+git add supabase-migrations/20260507_tagespuls_tables.sql supabase-schema.sql
+git commit -m "feat(db): tagespuls tables migration (TASK-T1)"
+```
+
+---
+
+### Task T2: Aphorismen seed (only after T0 PASS)
+
+**Files:**
+- Create: `scripts/seed-aphorisms.mjs` (Node, not Python — keeps it in npm scripts)
+- Modify: `package.json` (add `seed:aphorisms` script)
+
+**Step 1: Write the seed script**
+
+```js
+// scripts/seed-aphorisms.mjs
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const data = JSON.parse(readFileSync('apps/tagespuls_package/packages/voice/data/aphorisms.json', 'utf8'));
+const client = createClient(url, key);
+
+let inserted = 0;
+for (const a of data) {
+  const { error } = await client.from('aphorisms').upsert({
+    id: a.id,
+    status: a.status,
+    text_de: a.text.de,
+    text_en: a.text.en,
+    text_original: a.text.original ?? null,
+    author: a.source.author,
+    work: a.source.work ?? null,
+    year: a.source.year ?? null,
+    original_language: a.source.original_language,
+    translator_de: a.source.translator_de ?? null,
+    translator_en: a.source.translator_en ?? null,
+    copyright: a.copyright,
+    attribution_status: a.attribution_status,
+    attribution_note: a.attribution_note ?? null,
+    mode_tags: a.mode_tags,
+    tone_tags: a.tone_tags ?? [],
+    element_affinity: a.element_affinity ?? [],
+    figure_affinity: a.figure_affinity ?? [],
+    season_affinity: a.season_affinity ?? [],
+    word_count_de: a.word_count_de,
+    word_count_en: a.word_count_en,
+    quality_rating: a.quality_rating,
+    cooldown_days: a.cooldown_days ?? 30,
+  });
+  if (error) {
+    console.error(`Failed to seed ${a.id}:`, error.message);
+  } else {
+    inserted++;
+  }
+}
+console.log(`Seeded ${inserted}/${data.length} aphorisms`);
+```
+
+**Step 2: Add npm script**
+
+```json
+"seed:aphorisms": "node --env-file=.env scripts/seed-aphorisms.mjs"
+```
+
+**Step 3: Run**
+
+```bash
+npm run seed:aphorisms
+# Expected: "Seeded N/N aphorisms" where N >= 15
+```
+
+**Step 4: Verify in Supabase**
+
+```sql
+SELECT count(*) FROM aphorisms WHERE status = 'approved';
+-- Expected: >= 15
+```
+
+**Step 5: Commit**
+
+```bash
+git add scripts/seed-aphorisms.mjs package.json
+git commit -m "feat(seed): aphorisms seed script (TASK-T2)"
+```
+
+---
+
+### Task T3: Express route /api/daily-pulse (preferred over Edge Function)
+
+> **Architecture decision deviation from brief**: The brief specifies Supabase Edge Functions. The existing Bazodiac architecture uses an Express server (`server.mjs`) for ALL API routes — daily, transit-state, agent, checkout. Adding Edge Functions would introduce a new deployment surface, new auth boundary, new env-var management. Use Express to match existing pattern. Document this deviation in `2-design/decisions/DEC-tagespuls-on-express.md`.
+
+**Files:**
+- Create: `2-design/decisions/DEC-tagespuls-on-express.md`
+- Modify: `server.mjs` (add `/api/daily-pulse` route)
+- Test: `server/__tests__/daily-pulse-route.test.mjs`
+
+**Step 1: Document the architecture decision**
+
+Decision: keep Tagespuls on Express, not Edge Functions. Rationale: existing daily/transit/checkout routes are all on Express; introducing Edge Functions duplicates auth, deployment, observability. Edge Functions can be migration target after the feature stabilizes.
+
+**Step 2: Write integration test**
+
+```js
+// server/__tests__/daily-pulse-route.test.mjs
+// Mock Supabase + Gemini, hit GET /api/daily-pulse?date=2026-05-07&locale=de with valid JWT
+// Assert response shape: { id, date, mode, intensity, aphorism, slot_1, slot_2, slot_3, council, weather_stale }
+// Determinism: same userId+date+locale → same aphorism.id
+```
+
+**Step 3: Implement the route**
+
+```js
+// server.mjs
+app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
+  const userId = req.userId;
+  const { date = new Date().toISOString().slice(0, 10), locale = 'de' } = req.query;
+
+  // 1. Load user_astro_profiles row (or fall back to astro_profiles for now)
+  // 2. Load cosmic_weather_snapshots for date (or latest stale)
+  // 3. Compute harmony_index via dot-product (port from packages/voice/src/tagespuls.ts)
+  // 4. Compute mode + intensity via dayModeFromHarmony()
+  // 5. Load approved aphorisms filtered by mode_tags + cooldown
+  // 6. Run selectAphorism() — top-5 by quality_rating, hash(userId+date+mode) % 5
+  // 7. Generate slot_2 + slot_3 via Gemini (with OpenRouter fallback from HOTFIX-B)
+  // 8. Upsert daily_pulses row
+  // 9. Return response
+
+  // Error handling per brief: 422 if no profile, fallback aphorism if pool empty, retry-once on LLM error.
+});
+```
+
+Use `@bazodiac/shared` to import `selectAphorism` and `dayModeFromHarmony` from `apps/tagespuls_package/packages/voice/src/tagespuls.ts`. If that package isn't a workspace package, copy the two pure functions into `src/lib/daily-pulse/` and import there. Don't reinvent.
+
+**Step 4: Run tests + commit**
+
+```bash
+npx vitest run server/__tests__/daily-pulse-route.test.mjs
+git add server.mjs server/__tests__/daily-pulse-route.test.mjs \
+        2-design/decisions/DEC-tagespuls-on-express.md
+git commit -m "feat(api): /api/daily-pulse route (TASK-T3)"
+```
+
+---
+
+### Task T4: Express route /api/daily-interpretation
+
+**Files:**
+- Modify: `server.mjs`
+- Test: `server/__tests__/daily-interpretation-route.test.mjs`
+
+Mirror T3 structure for POST `/api/daily-interpretation`. Validate `selected_archetype_key` against the 6 council enum. LLM call uses `day-pulse-trace` skill content as system prompt. Cache by `(daily_pulse_id, selected_archetype_key, locale)` — same combo returns existing row, no re-LLM.
+
+**Commit message:** `feat(api): /api/daily-interpretation route (TASK-T4)`
+
+---
+
+### Task T5: useDailyPulse client hook
+
+**Files:**
+- Create: `src/hooks/useDailyPulse.ts`
+- Test: `src/__tests__/use-daily-pulse.test.ts`
+
+Mirror the contract from the brief. `useDailyPulse(userId, birthData, locale)` returns `{ pulse, council, interpretation, loading, loadingInterpretation, isFallback, selectCouncilFigure }`. Cache in `localStorage` by `daily_pulse_cache:${date}:${locale}`. `birthData === null` → `pulse: null` immediately.
+
+**Test cases:**
+- DP-001: birthData null → pulse null, no fetch
+- DP-002: happy path → fetches GET /api/daily-pulse, returns pulse + council
+- DP-003: API 500 → isFallback true, fallback pulse
+- DP-004: cache hit → no fetch
+- DP-005: selectCouncilFigure → POSTs /api/daily-interpretation, returns text
+- DP-006: same figure twice → uses cached interpretation
+
+**Commit message:** `feat(client): useDailyPulse hook (TASK-T5)`
+
+---
+
+### Task T6: TagespulsCard component
+
+**Files:**
+- Create: `src/components/dashboard/TagespulsCard.tsx`
+- Test: `src/__tests__/tagespuls-card.test.tsx`
+
+Two-phase card per brief:
+
+**Phase 1** (initial mount):
+- Mode chip (PULS/SPUR/SPANNUNG)
+- Aphorism (slot_1) + author
+- slot_2 (Brücke ins Heute)
+- slot_3 (Handlungsimpuls)
+- "Wer begleitet dich heute?" + 6 council buttons (Sun/Moon/Asc/DayMaster/YearAnimal/WuXing)
+
+**Phase 2** (after figure tap):
+- Selected figure name + glyph
+- interpretation.text
+- "Andere Figur wählen →" back-button
+
+**Loading state:** skeleton placeholders (no empty card).
+**Empty state (no profile):** Profile-CTA (mirror DailyChartHero).
+**Fallback state:** label per TASK-D2 pattern.
+
+**Test cases:** 10+ across phases, states, council selection, loading.
+
+**Commit message:** `feat(dashboard): TagespulsCard component (TASK-T6)`
+
+---
+
+### Task T7: Dashboard wiring + feature flag
+
+**Files:**
+- Modify: `src/lib/feature-flags.ts` (add `tagespuls_neu_v1: false`)
+- Modify: `src/components/Dashboard.tsx` (mount conditional on flag)
+- Test: `src/__tests__/dashboard-tagespuls-flag.test.tsx`
+
+**Step 1: Add flag**
+
+```ts
+// src/lib/feature-flags.ts
+const FLAGS = {
+  // ...existing
+  tagespuls_neu_v1: false,  // gate for the new aphorism-based card; co-exists with DailyChartHero
+};
+```
+
+**Step 2: Mount in Dashboard with flag check**
+
+```tsx
+const tagespulsNeuEnabled = isFeatureEnabled('tagespuls_neu_v1');
+const tagespuls = useDailyPulse(userId, profileMeta.birthInput, lang === 'en' ? 'en' : 'de');
+
+{/* Position: BEFORE DailyChartHero per brief — Tagespuls frames the day, DailyChartHero adds depth */}
+{tagespulsNeuEnabled && (
+  <SectionErrorBoundary name="TagespulsCard">
+    <TagespulsCard
+      pulse={tagespuls.pulse}
+      council={tagespuls.council}
+      interpretation={tagespuls.interpretation}
+      loading={tagespuls.loading}
+      isFallback={tagespuls.isFallback}
+      onSelectFigure={tagespuls.selectCouncilFigure}
+      locale={lang === 'en' ? 'en' : 'de'}
+    />
+  </SectionErrorBoundary>
+)}
+```
+
+**Step 3: Test the flag gate**
+
+```tsx
+it('TPF-001: TagespulsCard hidden when flag off (default)', () => { /* */ });
+it('TPF-002: TagespulsCard visible when flag on', () => { /* mock localStorage override */ });
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/lib/feature-flags.ts src/components/Dashboard.tsx \
+        src/__tests__/dashboard-tagespuls-flag.test.tsx
+git commit -m "feat(dashboard): mount TagespulsCard behind tagespuls_neu_v1 flag (TASK-T7)"
+```
+
+---
+
+## PR plan + acceptance criteria
+
+This plan ships as **3 PRs**. The CTA consolidation branch (`2026-05-07-dashboard-cta-consolidation`, 12 commits) is independent and can land first.
+
+### PR 1 — Hotfixes + Phase D + Phase 4 (today, 4-6h)
+
+Branch: `2026-05-07-dashboard-stability-hotfixes`. Pre-req: CTA consolidation merged.
+
+- [ ] HOTFIX-A: R3F data-* removed; `/signatur` no longer crashes
+- [ ] HOTFIX-B: OpenRouter fallback wired + 24h cache; user sees real horoscope when Gemini OK, fresh fallback only when both fail
+- [ ] TASK-D2: Fallback indicator visible
+- [ ] TASK-D4: Documentation comment on vertiefen-button
+- [ ] TASK-4.1/4.2/4.3: API contract documented + degraded states visible
+
+Acceptance:
+- [ ] `tsc --noEmit` clean
+- [ ] `npm run build` succeeds
+- [ ] `/signatur` loads without ErrorBoundary catch (manual smoke)
+- [ ] Real Gemini call → no fallback indicator on `/`
+- [ ] Mock Gemini outage → fallback indicator visible
+
+### PR 2 — Phase 2 + Phase 3 + Phase 5 (this week, 4-8h)
+
+Branch: `2026-05-07-dashboard-3d-anchor`. Pre-req: PR 1 merged.
+
+- [ ] TASK-2.1: Pipeline audit doc
+- [ ] TASK-2.2: SignaturAnchorCard mounted on dashboard
+- [ ] TASK-3.1: Section ordering audit + minimal reorder
+- [ ] TASK-3.2: Retention TODO markers
+- [ ] TASK-5.1: Visibility-aware polling
+- [ ] TASK-5.2: SpaceWeather hook deduplication
+
+Acceptance:
+- [ ] `/signatur` reachable from dashboard via SignaturAnchorCard
+- [ ] Network tab: 1 SpaceWeather poller (was 2)
+- [ ] Network tab: hidden tab → 60s polling (was 800ms / 15s)
+- [ ] `tsc --noEmit` clean
+
+### PR 3 — Phase T (gated) (timeline TBD — depends on PO approval cycle)
+
+Branch: `2026-05-07-tagespuls-architecture`. Pre-req: TASK-T0 PASS.
+
+- [ ] T0 gate: ≥15 approved aphorisms with 3-mode coverage
+- [ ] T1: tables migrated, schema parity preserved
+- [ ] T2: aphorisms seeded
+- [ ] T3: /api/daily-pulse returns valid response
+- [ ] T4: /api/daily-interpretation idempotent per (pulse_id, archetype_key, locale)
+- [ ] T5: useDailyPulse handles all 6 test cases
+- [ ] T6: TagespulsCard renders both phases + loading/empty/fallback
+- [ ] T7: feature flag gates the card; default off
+
+Acceptance:
+- [ ] With `tagespuls_neu_v1` localStorage override → TagespulsCard appears above DailyChartHero
+- [ ] Council figure tap → Phase 2 visible
+- [ ] Cache: same user same date → no second AI call
+- [ ] `tsc --noEmit` clean
+
+---
+
+## Done-when checklist
+
+- [ ] PR 1 merged: dashboard stable, /signatur loads, Tagesimpuls is real
+- [ ] PR 2 merged: 3D anchor on dashboard, polling clean
+- [ ] PR 3 merged: Tagespuls architecture live behind flag (when T0 passes)
+- [ ] CHANGELOG entries for each PR
+- [ ] `npm test`, `npm run lint`, `npm run build` all green at every PR boundary
+
+## Out of scope (deliberate)
+
+- Wu-Xing DE/EN drift fix in `bazi-to-chladni.ts` — separate fix-track per brief Hinweis #8
+- Replacing `/api/experience/daily` with `/api/daily-pulse` — both coexist this sprint per Hinweis #10
+- Migrating Phase T to Supabase Edge Functions — keep on Express; future migration target documented in DEC-tagespuls-on-express
+- Aphorism approval round itself — that's a PO content task, not a code task
+- Stripe rebuild revisions — already shipped 2026-05-07
+- Astrological formulas, scoring, ephemeris — explicitly forbidden by brief
+
+---
+
+## References
+
+- Brief: this user message (chat invocation, 2026-05-07)
+- CTA consolidation branch: `2026-05-07-dashboard-cta-consolidation` (12 commits, pushed, awaiting merge to main)
+- Tagespuls package: `apps/tagespuls_package/` — schema.sql, openapi.yaml, voice/src/tagespuls.ts, 21 review markdowns
+- Live investigation log (today): R3F data-tint crash, FuFirE 401, Gemini 429, aphorism count 0/16/5
+- Existing main app: `src/lib/daily-pulse/` — aphorism-select.ts, aphorism-to-wire.ts, council.ts, mode.ts (TS port already in place)
+- Memory: `feedback_schema_migration_alignment.md` — supabase-schema.sql + supabase-migrations/ must agree on end state

--- a/server.mjs
+++ b/server.mjs
@@ -1820,7 +1820,7 @@ function buildDailyFallbackPayload({ targetDate, lang, bafeData }) {
       harmony_index: harmonyIndex,
       day_mode: dayMode,
     },
-    meta: { engine_version: 'v1-gemini-daily' },
+    meta: { engine_version: 'v1-server-fallback' },
   };
 }
 
@@ -2897,27 +2897,38 @@ NEVER use in synthesis: "weil", "da heute", planet names (Mars, Venus etc.), "di
       appendNightHarmony(parsedData, now);
     }
 
-    horoscopeCache.set(cacheKeyD, { data: parsedData, timestamp: Date.now() });
+    // HOTFIX-B (cache-poisoning guard): refuse to cache server-side fallback payloads.
+    // When the AI provider returns empty/malformed output we still respond to the client,
+    // but caching the generic fallback would freeze every user on the same canned text for
+    // the next 24h (HOROSCOPE_CACHE_TTL) — even after Gemini quota resets at midnight UTC.
+    // Real AI responses still cache as before; only fallback short-circuits both L1 and L2.
+    const isServerFallback = parsedData?.meta?.engine_version === 'v1-server-fallback';
 
-    if (supabaseServer) {
-      // Persist to L2 (fire-and-forget) — badges not cached (computed fresh each request)
-      supabaseServer
-        .from('daily_horoscope_cache')
-        .upsert({
-          user_id: userId,
-          local_date: targetDate,
-          engine_version: 'v1-gemini-daily',
-          signature_version: 1,
-          payload_json: parsedData,
-        }, { onConflict: 'user_id,local_date,engine_version,signature_version' })
-        .then(({ error }) => {
-          if (error) {
-            console.warn('[daily] DB cache upsert failed:', error.message);
-          }
-        })
-        .catch((err) => {
-          console.error('[daily] DB cache upsert rejected:', err);
-        });
+    if (!isServerFallback) {
+      horoscopeCache.set(cacheKeyD, { data: parsedData, timestamp: Date.now() });
+
+      if (supabaseServer) {
+        // Persist to L2 (fire-and-forget) — badges not cached (computed fresh each request)
+        supabaseServer
+          .from('daily_horoscope_cache')
+          .upsert({
+            user_id: userId,
+            local_date: targetDate,
+            engine_version: 'v1-gemini-daily',
+            signature_version: 1,
+            payload_json: parsedData,
+          }, { onConflict: 'user_id,local_date,engine_version,signature_version' })
+          .then(({ error }) => {
+            if (error) {
+              console.warn('[daily] DB cache upsert failed:', error.message);
+            }
+          })
+          .catch((err) => {
+            console.error('[daily] DB cache upsert rejected:', err);
+          });
+      }
+    } else {
+      console.warn('[experience/daily] Skipping L1+L2 cache write for server fallback payload (forces retry on next request)');
     }
 
     const responseData = await prepareDailyResponse(parsedData);

--- a/server/__tests__/experience-daily-no-cache-poisoning.test.mjs
+++ b/server/__tests__/experience-daily-no-cache-poisoning.test.mjs
@@ -1,0 +1,269 @@
+// @vitest-environment node
+/**
+ * HOTFIX-B regression tests — refuse to cache server-side fallback payloads.
+ *
+ * Bug: when the AI provider returned empty / malformed JSON, the daily handler
+ * fell back to buildDailyFallbackPayload() and unconditionally wrote the result
+ * into both the L1 (in-memory horoscopeCache Map) and L2 (Supabase
+ * daily_horoscope_cache) caches. For the next 24h every request for the same
+ * (user, date, lang) returned the canned fallback text without retrying the
+ * AI router — even after Gemini quota reset. Symptom: "100% of users see the
+ * same Tagesimpuls" reported 2026-05-07.
+ *
+ * Fix: the fallback payload now carries `meta.engine_version === "v1-server-fallback"`,
+ * and both cache writes are gated on that field. Real AI responses still cache
+ * (engine_version === "v1-gemini-daily"); fallback responses go to the client
+ * but force a retry on the next request.
+ */
+import request from 'supertest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const AUTH_HEADER = { Authorization: 'Bearer test-token' };
+
+const BIRTH_BODY = {
+  birth: {
+    date: '1990-06-15',
+    time: '14:30:00',
+    lat: 52.52,
+    lon: 13.405,
+    tz: 'Europe/Berlin',
+  },
+  target_date: '2026-05-09',
+  locale: 'de',
+};
+
+/**
+ * Mock global fetch:
+ *   - Supabase auth.getUser returns user-1
+ *   - Supabase REST (astro_profiles, daily_horoscope_cache) returns empty
+ *   - BAFE /chart returns minimal natal data
+ *   - Anything else returns empty 200
+ */
+function mockExternalFetch() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input
+      : input instanceof URL ? input.toString()
+        : input?.url ?? '';
+
+    if (url.includes('auth/v1/user')) {
+      const userBody = { id: 'user-1', email: 't@test.com', aud: 'authenticated' };
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => userBody,
+        text: async () => JSON.stringify(userBody),
+      };
+    }
+
+    if (url.includes('/chart')) {
+      const bafe = {
+        western: { zodiac_sign: 'gemini', moon_sign: 'libra' },
+        bazi: { pillars: { day: { stem: 'jia' } } },
+        wuxing: { wood: 0.3, fire: 0.2, earth: 0.2, metal: 0.15, water: 0.15 },
+      };
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => bafe,
+        text: async () => JSON.stringify(bafe),
+      };
+    }
+
+    // Supabase REST default — empty list
+    return {
+      ok: true, status: 200,
+      headers: new Headers({ 'content-type': 'application/json', 'content-range': '0-0/0' }),
+      json: async () => [],
+      text: async () => '[]',
+    };
+  });
+}
+
+/** Wraps a Gemini SDK class returning a fixed text body. */
+function makeGeminiTextMock(text) {
+  return {
+    GoogleGenAI: class {
+      models = {
+        generateContent: vi.fn().mockResolvedValue({ text }),
+      };
+      getGenerativeModel = vi.fn().mockReturnValue({
+        generateContent: vi.fn().mockResolvedValue({ response: { text: () => '' } }),
+      });
+    },
+  };
+}
+
+/** Wraps a Gemini SDK class whose `generateContent` always throws (router exhaustion). */
+function makeGeminiAlwaysExhaustedMock() {
+  const err = Object.assign(new Error('quota exceeded'), { status: 429 });
+  return {
+    GoogleGenAI: class {
+      models = {
+        generateContent: vi.fn().mockRejectedValue(err),
+      };
+      getGenerativeModel = vi.fn().mockReturnValue({
+        generateContent: vi.fn().mockRejectedValue(err),
+      });
+    },
+  };
+}
+
+/**
+ * Reload server.mjs with a clean module graph + injected Gemini mock.
+ * OPENROUTER_API_KEY is intentionally NOT set so the router has only one
+ * provider (Gemini direct) — exhausting it means full chain exhaustion.
+ */
+async function loadApp(geminiMock) {
+  vi.resetModules();
+  process.env.NODE_ENV = 'test';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+  process.env.GEMINI_API_KEY = 'test-gemini-key';
+  process.env.BAFE_BASE_URL = 'https://bafe.test';
+  delete process.env.OPENROUTER_API_KEY;
+
+  if (geminiMock) {
+    vi.doMock('@google/genai', () => geminiMock);
+  }
+
+  const mod = await import('../../server.mjs');
+  return mod.app;
+}
+
+describe('experience/daily — fallback payloads must NOT poison caches (HOTFIX-B)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Note: each test calls loadApp() which uses vi.doMock + vi.resetModules,
+    // so we don't need (and can't safely use) vi.unmock at this scope —
+    // hoisting would make it run before any tests, undermining doMock.
+  });
+
+  it('EDF-NCP-001: real AI response IS cached (engine_version v1-gemini-daily)', async () => {
+    mockExternalFetch();
+    const goodPayload = {
+      date: '2026-05-09',
+      western: { summary: 'real ai output', themes: ['a'], caution: 'c', opportunity: 'o', evidence: { transit_sectors: [1] } },
+      eastern: { summary: 'real bazi', themes: ['b'], caution: 'c', opportunity: 'o', evidence: { day_master: 'jia' } },
+      fusion: {
+        summary: 'real fusion',
+        synthesis: 'Holz trifft auf Feuer.',
+        action: 'a',
+        pushworthy: true,
+        push_text: 'p',
+        harmony_index: 0.55,
+        day_mode: 'trace',
+      },
+      meta: { engine_version: 'v1-gemini-daily' },
+    };
+    const app = await loadApp(makeGeminiTextMock(JSON.stringify(goodPayload)));
+
+    const first = await request(app)
+      .post('/api/experience/daily')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send(BIRTH_BODY);
+
+    expect(first.status).toBe(200);
+    expect(first.body?.meta?.engine_version).toBe('v1-gemini-daily');
+    expect(first.body?.fusion?.synthesis).toContain('Holz');
+
+    // Second request with the same body must be served from L1 cache —
+    // we verify by counting fetch calls to the BAFE /chart endpoint:
+    // a cached response skips BAFE entirely.
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    const chartCallsBefore = fetchSpy.mock.calls.filter(([u]) =>
+      typeof u === 'string' && u.includes('/chart')
+    ).length;
+
+    const second = await request(app)
+      .post('/api/experience/daily')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send(BIRTH_BODY);
+
+    expect(second.status).toBe(200);
+    expect(second.body?.fusion?.synthesis).toContain('Holz');
+
+    const chartCallsAfter = fetchSpy.mock.calls.filter(([u]) =>
+      typeof u === 'string' && u.includes('/chart')
+    ).length;
+    expect(chartCallsAfter).toBe(chartCallsBefore); // L1 cache hit, BAFE NOT re-fetched
+  });
+
+  it('EDF-NCP-002: server fallback payload is RETURNED to client but NOT cached', async () => {
+    mockExternalFetch();
+    // Empty Gemini response → handler falls back to buildDailyFallbackPayload()
+    const app = await loadApp(makeGeminiTextMock(''));
+
+    const first = await request(app)
+      .post('/api/experience/daily')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send(BIRTH_BODY);
+
+    expect(first.status).toBe(200);
+    // Distinguishing marker: this is the server fallback, not a real AI response.
+    expect(first.body?.meta?.engine_version).toBe('v1-server-fallback');
+
+    // Now make a second request — if cache poisoning was happening, this
+    // would skip the AI router. Instead, BAFE /chart should be called again.
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    const chartCallsBefore = fetchSpy.mock.calls.filter(([u]) =>
+      typeof u === 'string' && u.includes('/chart')
+    ).length;
+
+    const second = await request(app)
+      .post('/api/experience/daily')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send(BIRTH_BODY);
+
+    expect(second.status).toBe(200);
+
+    const chartCallsAfter = fetchSpy.mock.calls.filter(([u]) =>
+      typeof u === 'string' && u.includes('/chart')
+    ).length;
+    // Critical assertion: BAFE was re-fetched, meaning the fallback was NOT
+    // served from L1 cache. The handler retried the full pipeline.
+    expect(chartCallsAfter).toBeGreaterThan(chartCallsBefore);
+  });
+
+  it('EDF-NCP-003: AI router exhausted → 502 to client AND no cache write (regression for "stuck Tagesimpuls")', async () => {
+    mockExternalFetch();
+    // Router throws on every call. Since OPENROUTER_API_KEY is unset, the
+    // chain is just Gemini direct → router fully exhausts → handler catches
+    // and returns 502. Critically, no cache write happens at all.
+    const app = await loadApp(makeGeminiAlwaysExhaustedMock());
+
+    const fetchSpy = vi.mocked(globalThis.fetch);
+
+    const first = await request(app)
+      .post('/api/experience/daily')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send(BIRTH_BODY);
+
+    expect(first.status).toBe(502);
+    expect(first.body?.error).toBe('experience_unavailable');
+
+    const chartCallsBefore = fetchSpy.mock.calls.filter(([u]) =>
+      typeof u === 'string' && u.includes('/chart')
+    ).length;
+
+    // Second request must invoke the full pipeline again — not be served from
+    // any cache layer. This is the user-reported "Heute fließt deine Energie
+    // ruhig" regression: the second call must hit the AI router fresh.
+    const second = await request(app)
+      .post('/api/experience/daily')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send(BIRTH_BODY);
+
+    expect(second.status).toBe(502);
+
+    const chartCallsAfter = fetchSpy.mock.calls.filter(([u]) =>
+      typeof u === 'string' && u.includes('/chart')
+    ).length;
+    expect(chartCallsAfter).toBeGreaterThan(chartCallsBefore); // BAFE hit again, no cache short-circuit
+  });
+});

--- a/src/__tests__/daily-chart-hero-driver-dashes.test.tsx
+++ b/src/__tests__/daily-chart-hero-driver-dashes.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * DailyChartHero — Driver Strip em-dash placeholders (TASK-4.3).
+ *
+ * The Driver Strip renders three space-weather values: geomagnetic Kp,
+ * solar pressure, transit activity. When upstream values are null/undefined
+ * (NOAA SWPC outage, useSpaceWeather() pre-resolve, malformed cache), the
+ * previous code rendered "Kp null", "0%" (misleading), or crashed on
+ * `.toFixed()` / `.length` access.
+ *
+ * Now nullish values render as em-dash "—" — visible degraded state, no
+ * crash, no misleading data.
+ *
+ * See docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md §Task 4.3.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DailyChartHero } from '../components/dashboard/DailyChartHero';
+import type { SpaceWeatherState } from '../hooks/useSpaceWeather';
+
+vi.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de', t: (k: string) => k }),
+}));
+
+vi.mock('../lib/astro-data/planetInfluences', () => ({
+  computeTodayPlanetInfluences: vi.fn(() => null),
+  zodiacSignToIndex: vi.fn(() => -1),
+}));
+
+const HEALTHY_SPACE_WEATHER: SpaceWeatherState = {
+  kpIndex: 3,
+  solarPressure: 0.42,
+  ringModulation: 1,
+  intensityBoost: 0,
+  triggerEffect: false,
+  gScale: 'G0',
+  xrayFlux: 0,
+  xrayClass: 'A',
+  protonFlux: 0,
+  f107: 70,
+  solarCyclePhase: 'minimum',
+  events: [],
+  alerts: [],
+  lastUpdate: null,
+  loading: false,
+  error: null,
+};
+
+const baseProps = {
+  loading: false,
+  baseCoherence: 60,
+  positiveDailyDelta: 0,
+  displayedCoherence: 60,
+  spaceWeather: HEALTHY_SPACE_WEATHER,
+  transitEvents: [],
+  dayMode: 'pulse' as const,
+  birthSign: 'Aries',
+  impulsText: 'Some daily impulse.',
+  profileIncomplete: false,
+  onCompleteProfile: () => {},
+  onOpenDayModal: () => {},
+};
+
+describe('DailyChartHero Driver Strip dashes (TASK-4.3)', () => {
+  it('DCH-DASH-001: renders normal numeric values when all spaceWeather fields are present (regression)', () => {
+    render(<DailyChartHero {...baseProps} />);
+    const strip = screen.getByTestId('driver-strip');
+    // Happy path: real values render
+    expect(strip).toHaveTextContent('Kp 3');
+    expect(strip).toHaveTextContent('42%');
+    expect(strip).toHaveTextContent('0');
+    // No em-dash on healthy data
+    expect(strip).not.toHaveTextContent('—');
+  });
+
+  it('DCH-DASH-002: renders em-dash when kpIndex is null', () => {
+    const partial = {
+      ...HEALTHY_SPACE_WEATHER,
+      kpIndex: null,
+    } as unknown as SpaceWeatherState;
+    render(<DailyChartHero {...baseProps} spaceWeather={partial} />);
+    const strip = screen.getByTestId('driver-strip');
+    expect(strip).toHaveTextContent('—');
+    // Solar pressure still renders normally (independent guard)
+    expect(strip).toHaveTextContent('42%');
+    // Must NOT render the misleading "Kp null"
+    expect(strip).not.toHaveTextContent('Kp null');
+    expect(strip).not.toHaveTextContent('NaN');
+  });
+
+  it('DCH-DASH-003: renders em-dash for all three drivers when spaceWeather is fully degraded', () => {
+    const allNull = {
+      ...HEALTHY_SPACE_WEATHER,
+      kpIndex: null,
+      solarPressure: null,
+    } as unknown as SpaceWeatherState;
+    render(
+      <DailyChartHero
+        {...baseProps}
+        spaceWeather={allNull}
+        transitEvents={undefined as never}
+      />,
+    );
+    const strip = screen.getByTestId('driver-strip');
+    // All three slots must show em-dash
+    const dashes = strip.textContent?.match(/—/g) ?? [];
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+    // No crash, no misleading values
+    expect(strip).not.toHaveTextContent('NaN');
+    expect(strip).not.toHaveTextContent('null');
+    expect(strip).not.toHaveTextContent('undefined');
+  });
+});

--- a/src/__tests__/daily-chart-hero-fallback-label.test.tsx
+++ b/src/__tests__/daily-chart-hero-fallback-label.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * DailyChartHero — fallback indicator (TASK-D2).
+ *
+ * When useFirstRunDaily() falls back to buildFallbackDaily() (FuFirE/Gemini
+ * down), meta.engine_version === 'v1-local-fallback' is set. Dashboard.tsx
+ * forwards that as `isFallback` to DailyChartHero, which renders a small,
+ * low-contrast indicator under the Tagesimpuls paragraph so the user knows
+ * the content is generic rather than a real personalized horoscope.
+ *
+ * See docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md §Task D2.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DailyChartHero } from '../components/dashboard/DailyChartHero';
+import type { SpaceWeatherState } from '../hooks/useSpaceWeather';
+
+vi.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de', t: (k: string) => k }),
+}));
+
+vi.mock('../lib/astro-data/planetInfluences', () => ({
+  computeTodayPlanetInfluences: vi.fn(() => null),
+  zodiacSignToIndex: vi.fn(() => -1),
+}));
+
+const NULL_SPACE_WEATHER: SpaceWeatherState = {
+  kpIndex: 0,
+  solarPressure: 0,
+  ringModulation: 1,
+  intensityBoost: 0,
+  triggerEffect: false,
+  gScale: 'G0',
+  xrayFlux: 0,
+  xrayClass: 'A',
+  protonFlux: 0,
+  f107: 70,
+  solarCyclePhase: 'minimum',
+  events: [],
+  alerts: [],
+  lastUpdate: null,
+  loading: false,
+  error: null,
+};
+
+const baseProps = {
+  loading: false,
+  baseCoherence: 60,
+  positiveDailyDelta: 0,
+  displayedCoherence: 60,
+  spaceWeather: NULL_SPACE_WEATHER,
+  transitEvents: [],
+  dayMode: 'pulse' as const,
+  birthSign: 'Aries',
+  impulsText: 'Generic fallback text.',
+  profileIncomplete: false,
+  onCompleteProfile: () => {},
+  onOpenDayModal: () => {},
+};
+
+describe('DailyChartHero fallback indicator (TASK-D2)', () => {
+  it('DCH-FB-001: shows fallback indicator when isFallback=true and impuls is present', () => {
+    render(<DailyChartHero {...baseProps} isFallback={true} />);
+    expect(screen.getByTestId('fallback-indicator')).toBeInTheDocument();
+    expect(screen.getByText(/Heute nicht verfügbar/i)).toBeInTheDocument();
+  });
+
+  it('DCH-FB-002: NO indicator when isFallback=false (default)', () => {
+    render(<DailyChartHero {...baseProps} isFallback={false} />);
+    expect(screen.queryByTestId('fallback-indicator')).not.toBeInTheDocument();
+  });
+
+  it('DCH-FB-003: NO indicator when isFallback=true but impulsText empty', () => {
+    render(
+      <DailyChartHero
+        {...baseProps}
+        isFallback={true}
+        impulsText={undefined}
+        profileIncomplete={true}
+      />,
+    );
+    expect(screen.queryByTestId('fallback-indicator')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -385,6 +385,9 @@ export function Dashboard({
             impulsText={dailyData?.fusion?.synthesis || dailyData?.fusion?.summary}
             profileIncomplete={!metaLoading && !metaError && profileMeta.birthInput === null}
             onCompleteProfile={onReset}
+            // onOpenDayModal is intentionally passed regardless of dailyData
+            // presence. Fallback data is a valid basis for opening the detail
+            // modal; the modal itself handles fallback-aware rendering.
             onOpenDayModal={dailyEnabled ? () => setIsDayModalOpen(true) : undefined}
             isFallback={dailyData?.meta?.engine_version === 'v1-local-fallback'}
           />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -386,6 +386,7 @@ export function Dashboard({
             profileIncomplete={!metaLoading && !metaError && profileMeta.birthInput === null}
             onCompleteProfile={onReset}
             onOpenDayModal={dailyEnabled ? () => setIsDayModalOpen(true) : undefined}
+            isFallback={dailyData?.meta?.engine_version === 'v1-local-fallback'}
           />
         </SectionErrorBoundary>
       </motion.div>

--- a/src/components/dashboard/DailyChartHero.tsx
+++ b/src/components/dashboard/DailyChartHero.tsx
@@ -65,6 +65,13 @@ export interface DailyChartHeroProps {
   onCompleteProfile?: () => void;
   /** Optional callback to open the day-detail modal (feature-flagged) */
   onOpenDayModal?: () => void;
+  /**
+   * True when `dailyData.meta.engine_version === 'v1-local-fallback'`, i.e.
+   * useFirstRunDaily fell back to buildFallbackDaily because FuFirE/Gemini
+   * was unreachable. Renders a small low-contrast indicator under the
+   * Tagesimpuls paragraph so users know the content is generic.
+   */
+  isFallback?: boolean;
 }
 
 // ── Split Coherence Ring ───────────────────────────────────────────────────────
@@ -223,6 +230,7 @@ export function DailyChartHero({
   profileIncomplete,
   onCompleteProfile,
   onOpenDayModal,
+  isFallback = false,
 }: DailyChartHeroProps) {
   const { lang } = useLanguage();
   const isDe = lang === 'de';
@@ -411,6 +419,17 @@ export function DailyChartHero({
           >
             {impulsText}
           </p>
+          {isFallback && (
+            <p
+              className="text-[9px] text-center mt-2"
+              style={{ color: 'var(--tile-text-secondary)', opacity: 0.4 }}
+              data-testid="fallback-indicator"
+            >
+              {isDe
+                ? '↻ Heute nicht verfügbar — generischer Inhalt'
+                : '↻ Unavailable today — generic content'}
+            </p>
+          )}
           {onOpenDayModal && (
             <div className="mt-3 text-center">
               <button

--- a/src/components/dashboard/DailyChartHero.tsx
+++ b/src/components/dashboard/DailyChartHero.tsx
@@ -239,23 +239,35 @@ export function DailyChartHero({
   const base = baseCoherence ?? displayed;
   const delta = positiveDailyDelta ?? 0;
 
+  // Defensive null-guards: spaceWeather and individual values may be null/undefined
+  // during NOAA SWPC outages, before useSpaceWeather() resolves, or when an old
+  // localStorage cache hydrates with missing keys. Render em-dash "—" for any
+  // missing value — visible degraded state, no crash, no misleading "Kp null"
+  // or "0%" rendering. (TASK-4.3)
+  const kp = spaceWeather?.kpIndex;
+  const sp = spaceWeather?.solarPressure;
+  const transitCount = transitEvents?.length;
   const drivers = useMemo(() => [
     {
       label: isDe ? 'Geomagnetik' : 'Geomagnetic',
-      value: `Kp ${spaceWeather.kpIndex}`,
-      state: classifyKp(spaceWeather.kpIndex),
+      value: kp != null && Number.isFinite(kp) ? `Kp ${kp}` : '—',
+      state: kp != null && Number.isFinite(kp) ? classifyKp(kp) : 'calm' as const,
     },
     {
       label: isDe ? 'Solardruck' : 'Solar pressure',
-      value: `${Math.round(spaceWeather.solarPressure * 100)}%`,
-      state: classifySolarPressure(spaceWeather.solarPressure),
+      value: sp != null && Number.isFinite(sp) ? `${Math.round(sp * 100)}%` : '—',
+      state: sp != null && Number.isFinite(sp) ? classifySolarPressure(sp) : 'calm' as const,
     },
     {
       label: isDe ? 'Transit-Aktivität' : 'Transit activity',
-      value: `${transitEvents.length} ${isDe ? 'aktiv' : 'active'}`,
-      state: classifyTransitCount(transitEvents.length),
+      value: transitCount != null
+        ? `${transitCount} ${isDe ? 'aktiv' : 'active'}`
+        : '—',
+      state: transitCount != null
+        ? classifyTransitCount(transitCount)
+        : 'calm' as const,
     },
-  ], [spaceWeather.kpIndex, spaceWeather.solarPressure, transitEvents.length, isDe]);
+  ], [kp, sp, transitCount, isDe]);
 
   if (loading) return <DailyChartHeroSkeleton />;
 

--- a/src/components/signatur-3d/SignatureSphere3D.tsx
+++ b/src/components/signatur-3d/SignatureSphere3D.tsx
@@ -370,7 +370,6 @@ function AnimatedScene({
         <mesh
           geometry={wireGeom}
           raycast={SKIP_RAYCAST}
-          data-mesh-role="wire-halo"
           scale={1.005}
           renderOrder={1}
         >
@@ -387,8 +386,6 @@ function AnimatedScene({
         <mesh
           geometry={wireGeom}
           raycast={SKIP_RAYCAST}
-          data-mesh-role="wire"
-          data-tint="gold"
           renderOrder={2}
         >
           <meshStandardMaterial
@@ -408,7 +405,6 @@ function AnimatedScene({
         <mesh
           geometry={solidGeom}
           raycast={SKIP_RAYCAST}
-          data-mesh-role="solid"
           material={wuxingMaterial}
         />
 

--- a/src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx
+++ b/src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx
@@ -216,39 +216,6 @@ describe('SignatureSphere3D', () => {
     expect(el?.getAttribute('data-element')).toBe('Water');
   });
 
-  // ── Task-5b additions ─────────────────────────────────────────────────────
-
-  it('wire layer carries gold-tint role marker', () => {
-    const { container } = render(
-      <SignatureSphere3D weights={{ Sun: 0.5 }} dominantElement="Water" />
-    );
-    const wireMesh = container.querySelector('[data-mesh-role="wire"]');
-    expect(wireMesh).not.toBeNull();
-    expect(wireMesh?.getAttribute('data-tint')).toBe('gold');
-  });
-
-  // ── Task-5c additions ─────────────────────────────────────────────────────
-
-  it('wire layer has both main and halo meshes', () => {
-    const { container } = render(
-      <SignatureSphere3D weights={{ Sun: 0.5 }} dominantElement="Earth" />
-    );
-    const main = container.querySelector('[data-mesh-role="wire"]');
-    const halo = container.querySelector('[data-mesh-role="wire-halo"]');
-    expect(main).not.toBeNull();
-    expect(halo).not.toBeNull();
-  });
-
-  // ── Task-6 additions ─────────────────────────────────────────────────────
-
-  it('solid layer uses a ShaderMaterial when dominantElement is set', async () => {
-    const { container } = render(
-      <SignatureSphere3D weights={{ Sun: 0.5 }} dominantElement="Metal" />
-    );
-    const solidLayer = container.querySelector('[data-mesh-role="solid"]');
-    expect(solidLayer).not.toBeNull();
-  });
-
   it('frame callback is a no-op when prefersReducedMotion is true', () => {
     // Force the motion/react hook to report reduced-motion for this render.
     useReducedMotionMock.mockReturnValue(true);

--- a/src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx
+++ b/src/components/signatur-3d/__tests__/no-r3f-data-attrs.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('SignatureSphere3D — no data-* on R3F nodes (HOTFIX-A)', () => {
+  it('SS3D-NO-DATA-001: source has no data-mesh-role attribute', () => {
+    const src = readFileSync(resolve(__dirname, '../SignatureSphere3D.tsx'), 'utf8');
+    expect(src).not.toMatch(/data-mesh-role/);
+  });
+  it('SS3D-NO-DATA-002: source has no data-tint attribute', () => {
+    const src = readFileSync(resolve(__dirname, '../SignatureSphere3D.tsx'), 'utf8');
+    expect(src).not.toMatch(/data-tint/);
+  });
+});

--- a/src/hooks/useActiveImpacts.ts
+++ b/src/hooks/useActiveImpacts.ts
@@ -109,6 +109,9 @@ export function useActiveImpacts(): ActiveImpactsState {
         const response = await authedFetch('/api/impact/active', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          // Contract: server is profile-driven (resolves req.userId from session
+          // via requireUserAuth, loads astro_profiles + computes impacts
+          // server-side). Empty body is intentional — see server.mjs:2198.
           body: '{}',
         });
 


### PR DESCRIPTION
## Summary
- **HOTFIX-A — `/signatur` no longer crashes**: removed `data-mesh-role` / `data-tint` JSX attributes from R3F `<mesh>` nodes in `SignatureSphere3D.tsx`. `applyProps` was treating them as Three.js property setters → `Cannot set "data-tint"` → ErrorBoundary → "Etwas ist schiefgelaufen" overlay. **This was the actual root cause of "Signatur kaputt" — not data flow.** 3 obsolete sibling tests deleted (they only passed because the Canvas mock short-circuits `applyProps`, validating the bug not the feature). Source-level guard tests prevent re-introduction.
- **HOTFIX-B — `/api/experience/daily` cache no longer poisoned by fallback payloads**: when the AI router fully exhausts (Gemini 429 + OpenRouter unset/exhausted/empty/malformed), the daily handler falls back to `buildDailyFallbackPayload()`. Previously this fallback was written into both L1 in-memory `horoscopeCache` and L2 `daily_horoscope_cache` Supabase table — locking every user into the same generic "Heute fließt deine Energie ruhig…" for 24h. Fix: gate both writes on `parsedData.meta.engine_version !== 'v1-server-fallback'`. Real responses cache; fallbacks force a retry next request. **Original plan's HOTFIX-B (OpenRouter fallback + 24h cache) was already implemented in `server/ai-router.mjs` and `server.mjs:1563`** — the live investigation surfaced this narrower bug.
- **TASK-D2 — visible fallback indicator on DailyChartHero**: new optional `isFallback` prop renders 9px-opacity-40% line "↻ Heute nicht verfügbar — generischer Inhalt" / "↻ Unavailable today — generic content" when `dailyData.meta.engine_version === 'v1-local-fallback'`.
- **TASK-4.3 — em-dash placeholders for null Driver-Strip values**: Kp / solar pressure / transit count render `—` instead of crashing on `.toFixed()` or showing `NaN%`.
- **TASK-4.1, 4.2, D4 — documentation**: `/api/impact/active` server-profile-driven contract documented; coherence data-source audit (single source of truth verified, sharp-edge surfaced: Zod schema doesn't enforce `displayed === base + delta`); vertiefen-button is fallback-agnostic by design.
- Implementation plan: `docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md` (PR 1 = HOTFIX-A + HOTFIX-B + Phase D + Phase 4).

## Test plan
- [ ] `npm test` — full suite green (2288/2288, was 2280/2280)
- [ ] `npm run lint` — clean
- [ ] `npm run build` — succeeds
- [ ] Manual smoke: open `/signatur` → 3D sphere renders, no ErrorBoundary catch
- [ ] Manual smoke: provoke fallback (block `/api/experience/daily`) → DailyChartHero shows fallback indicator under impuls
- [ ] Manual smoke: provoke NOAA outage / null spaceWeather → Driver Strip shows `—`, no NaN
- [ ] Sanity check the cache-poisoning fix: hit `/api/experience/daily` once with broken AI → response is fallback, but second call retries the AI router (look at server logs for the cache-skip path)

## Stacked PR
This PR depends on [#PR1: Dashboard CTA Consolidation](../tree/2026-05-07-dashboard-cta-consolidation). Merge order: CTA → this → 3D Anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)