### PR TITLE
Dashboard 3D Anchor + GreenOps (PR 2 of dashboard-flow plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [Unreleased] - 2026-05-07 — Dashboard 3D Anchor + GreenOps (PR 2 of dashboard-flow-tagespuls plan)
+
+### Features
+
+- **`SignaturAnchorCard` on the dashboard** (`src/components/dashboard/SignaturAnchorCard.tsx`, `src/components/Dashboard.tsx`, `src/i18n/translations.ts`) — new static anchor section between `DailyChartHero` and `AgentSection`. Shows the user's birth sign + dominant Wu-Xing element with a "Signatur ansehen →" / "View signature →" CTA navigating to `/signatur`. **No WebGL on the dashboard mount** — performance-safe, the 3D Chladni sphere only loads when the user explicitly opts in by tapping the CTA. Empty state ("Profil unvollständig" / "Profile incomplete") when either prop is missing. Brief calls this "Option B"; Option A (embedded R3F on dashboard) is deferred until B is stable in prod. New i18n subkey `signatur.anchor.{title,cta,empty}` (DE+EN).
+
+### Performance
+
+- **Visibility-aware Signatur polling** (`src/hooks/useSignaturSignal.ts`) — bumped `VISIBLE_INTERVAL` from 8s to 15s and `HIDDEN_INTERVAL` from 45s to 60s. The hook had been hardened on 2026-05-06 with visibility detection, exponential-backoff on errors, and `online`/`offline` listeners — this task just shifts the cadence per the dashboard-flow plan's GreenOps targets. The plan's "currently every 800ms" framing referred to the legacy regression baseline; the actual code was already self-rescheduling at sane intervals. Net effect: ~50% reduction in transit-state requests for an active session, more during background tabs.
+- **Single `useSpaceWeather()` poller per dashboard mount** (`src/components/dashboard/MagnetsturmKarte.tsx`, `src/components/Dashboard.tsx`) — `MagnetsturmKarte` previously called `useSpaceWeather()` directly, duplicating the 5-minute NOAA SWPC poller already running in `Dashboard.tsx`. Now `MagnetsturmKarte` accepts `spaceWeather` as a prop; Dashboard is the single hook caller and passes the value down. Reduces NOAA SWPC requests from 2 → 1 per 5-min window per dashboard mount. The `useSpaceWeather()` callsites in `SignaturPage.tsx` and `SignaturRenderer.tsx` were intentionally left untouched — separate page mounts have separate page-scoped pollers, which is correct.
+
+### Documentation
+
+- **3D Signatur pipeline audit** (`docs/2026-05-07-signatur-3d-pipeline-audit.md`) — verdict: ✅ **robust**. The Wu-Xing DE/EN drift hypothesis was **refuted**. Both `services/api.ts` (mapper writing 10-key dict with EN+DE entries) AND `baziToChladniParams` itself (via `normalizeWuxingElementKey`, accepting `feuer/holz/wasser/erde/metall` case-insensitively) independently handle bilingual input. **No separate fix-track needed.** Two minor cosmetic observations: zero-weight profiles bias to Water due to `best = 'Water'` initialization, and `harmony_index` field read via dynamic key access never finds the field (cosmetic, not user-facing).
+- **Dashboard hierarchy audit** (`docs/2026-05-07-dashboard-hierarchy-audit.md`) — verdict: 🚨 **major mismatch deferred**. 5 of 8 brief-target sections aligned (DailyChartHero #1, SignaturAnchorCard #2, AgentSection #3, DashboardAstroSection #4, DashboardBottomUpgradeCard #8). 1 section out of order (`DashboardInterpretationSection` is at position #9, brief said #5 — moving up 4 slots crosses `planetariumSentinelRef`, `navHintsSentinelRef`, the `#interpretation-section` deep-link anchor, the Planetarium block, MagnetsturmKarte, and the Bottom Upgrade Card; non-mechanical reorder). 1 section in the brief that's not in code (`DashboardTagesEnergie` was deliberately retired in commit `882eea8` 2026-04-15 as a duplicate of DailyChartHero — the brief target is stale here). 4 sections in code that aren't in the brief (BirthChartOrrery, SkyModeToggle, ShareCard, LegalFooter — likely intentional). Reorder deferred to a dedicated PO-led hierarchy sprint. **Plan recommendation:** update the `2026-05-07-dashboard-flow-tagespuls-3d.md` target to drop `DashboardTagesEnergie` and either keep Interpretation at the epilogue position or formally re-confirm intended position before code changes.
+
+### Tests / Refactoring
+
+- **3 SignaturAnchorCard tests** (`src/__tests__/signatur-anchor-card.test.tsx`) — `SAC-001/002/003` covering preview render, navigation on click, empty-state-when-no-profile.
+- **3 visibility-aware polling tests** (`src/__tests__/use-signatur-signal-polling.test.ts`) — `USS-POLL-001/002/003`/004/005 covering visible 15s cadence, hidden 60s cadence, immediate refresh on visibility change.
+- **1 prop-driven MagnetsturmKarte test** (`src/__tests__/magnetsturm-karte-prop-driven.test.tsx`) — `MK-PROP-001` asserting render-from-prop without hook call. **12 existing tests in `src/__tests__/MagnetsturmKarte.test.tsx`** adapted to the new prop interface (no deletions; mock pattern `vi.mock('../hooks/useSpaceWeather', ...)` swapped for inline fixture passed via `spaceWeather` prop).
+- **`TODO(analytics):` markers** at three user-action surfaces (`src/components/Dashboard.tsx`, `src/components/dashboard/DayModeModal.tsx`, `src/components/dashboard/SignaturAnchorCard.tsx`) for `dashboard_first_interaction`, `daily_detail_open_rate`, `signatur_sphere_interaction`. Stubs only — future analytics-focused sprint will wire `trackEvent` calls.
+- Full suite: **2299/2299 passing** (was 2288/2288 at end of PR 1; net +11 = +3 SAC +5 polling +3 KP +1 MK-PROP −1 from re-running the existing 12 MK tests with the new fixture). 248 test files. `tsc --noEmit` clean. `npm run build` succeeds in 11.90s.
+
+### Notes
+
+- Implementation plan: `docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md` (PR 2 = Phase 2 + Phase 3 + Phase 5).
+- The plan's TASK-5.1 referenced 800ms polling — that was the historical regression baseline, not the current state. The hook was already at 8s/45s after the 2026-05-06 backend hardening sprint. This task just bumped the constants to align with the dashboard-flow plan's targets (15s/60s).
+- The plan's TASK-3.1 expected DashboardTagesEnergie in the dashboard hierarchy, but it was deliberately retired 3 weeks ago as a duplicate of DailyChartHero. The hierarchy audit recommends the plan be updated rather than the code reverted.
+- Pending follow-ups (not blocking): (a) deduplicate `useSpaceWeather()` between SignaturPage and SignaturRenderer if they ever co-mount; (b) zero-weight profile bias to Water in `baziToChladniParams` is cosmetic but worth fixing if user reports surface; (c) PO refinement of dashboard hierarchy target before TASK-3.1 reorder is attempted; (d) wire actual `trackEvent` calls behind the new TODO markers when the analytics sprint runs.
+
 ## [Unreleased] - 2026-05-07 — Dashboard Stability Hotfixes (PR 1 of dashboard-flow-tagespuls plan)
 
 ### Bug fixes

--- a/docs/2026-05-07-dashboard-hierarchy-audit.md
+++ b/docs/2026-05-07-dashboard-hierarchy-audit.md
@@ -1,0 +1,140 @@
+# Dashboard hierarchy audit (TASK-3.1)
+
+**Date:** 2026-05-07
+**Branch:** `2026-05-07-dashboard-3d-anchor`
+**HEAD before audit:** `83c2cb1` (TASK-2.2 SignaturAnchorCard mounted)
+**Plan reference:** `docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md` § Task 3.1
+**Pre-req:** TASK-2.2 SignaturAnchorCard mounted (commit `83c2cb1`).
+
+## Brief target
+
+The plan defines 8 sections in a single linear hierarchy:
+
+| # | Section | Purpose |
+|---|---|---|
+| 1 | DailyChartHero | "Was ist heute los" — unified volatile hero |
+| 2 | SignaturAnchorCard | "Wer bin ich" — persistent identity preview |
+| 3 | AgentSection | Vertiefen via voice |
+| 4 | DashboardAstroSection | Big Four (PremiumGate, info-only) |
+| 5 | DashboardInterpretationSection | AI-Synthese (PremiumGate) |
+| 6 | DashboardTagesEnergie | Day-Pulse details |
+| 7 | MagnetsturmKarte | Space weather card |
+| 8 | DashboardBottomUpgradeCard | Single upgrade CTA (free only) |
+
+## Current order (post TASK-2.2)
+
+| # | Section | File:line | Gated by | Notes |
+|---|---|---|---|---|
+| 1 | DailyChartHero | `Dashboard.tsx:375` | none (loading prop) | Aligned with target #1 |
+| 2 | SignaturAnchorCard | `Dashboard.tsx:399` | none | NEW (2026-05-07, TASK-2.2). Aligned with target #2 |
+| 3 | AgentSection (×N grid) | `Dashboard.tsx:415` | premium gated per agent | Aligned with target #3 |
+| 4 | NatalSignaturStatic → DashboardAstroSection | `Dashboard.tsx:444` | PremiumGate inside | Aligned with target #4 (wrapped in NatalSignaturStatic accordion) |
+| 5 | BirthChartOrrery (Planetarium) | `Dashboard.tsx:462` | Suspense lazy-load | **Not in brief target** — present in code |
+| 6 | SkyModeToggle | `Dashboard.tsx:487` | `planetariumMode` only | **Not in brief target** — present in code |
+| 7 | MagnetsturmKarte | `Dashboard.tsx:493` | self-hides when Kp < 4 | Brief target #7 — **moved up by 2 vs target** |
+| 8 | DashboardBottomUpgradeCard | `Dashboard.tsx:500` | free users only (internal) | Brief target #8 — aligned |
+| 9 | DashboardInterpretationSection | `Dashboard.tsx:509` | PremiumGate inside | Brief target #5 — **off by 4 positions** |
+| 10 | ShareCard | `Dashboard.tsx:519` | none | **Not in brief target** — present in code |
+| 11 | LegalFooter | `Dashboard.tsx:526` | none | **Not in brief target** — present in code |
+
+`DashboardTagesEnergie` is **deliberately not mounted**. It was removed in commit
+`882eea8` ("fix(S-DCH-BUGFIX): 5 regression fixes + day-modal trigger rewiring",
+2026-04-15) with the rationale: *"Remove duplicate DashboardTagesEnergie section
+from Dashboard.tsx … Wire onOpenDayModal into DailyChartHero after TagesEnergie
+removal."* The Day-Pulse content is now owned by DailyChartHero (volatile hero
+via `DEC-dashboard-volatile-first`). The component file still exists at
+`src/components/dashboard/DashboardTagesEnergie.tsx` and is referenced from
+tests only.
+
+## Diff against target
+
+### Sections aligned (5 of 8)
+
+- **DailyChartHero** (target #1, current #1) — match
+- **SignaturAnchorCard** (target #2, current #2) — match
+- **AgentSection** (target #3, current #3) — match
+- **DashboardAstroSection** (target #4, current #4) — match (wrapped in `NatalSignaturStatic`)
+- **DashboardBottomUpgradeCard** (target #8, current #8) — match (after MagnetsturmKarte)
+
+### Sections out of order (1)
+
+- **DashboardInterpretationSection**
+  - Target position: #5 (right after DashboardAstroSection)
+  - Current position: #9 (after Planetarium, SkyModeToggle, MagnetsturmKarte, DashboardBottomUpgradeCard)
+  - Reordering risk: **medium-to-high**. Moving it up by 4 slots crosses:
+    1. `planetariumSentinelRef` (tour overlay step anchor, line 461)
+    2. `BirthChartOrrery` Suspense wrapper (line 462)
+    3. `SkyModeToggle` conditional (line 486–490)
+    4. `MagnetsturmKarte` (line 493)
+    5. `DashboardBottomUpgradeCard` (line 500)
+    6. `navHintsSentinelRef` (tour overlay step anchor, line 504)
+    7. `<div id="interpretation-section" />` deep-link anchor (line 506)
+  - The `interpretation-section` anchor appears to be referenced by deep links
+    or scroll-to behavior; its placement currently sits immediately above the
+    section. Moving the section without also moving the anchor would break it.
+  - The fadeIn cadence (`0.02 → 0.08 → 0.14 → 0.20 → 0.22 → 0.26 → 0.28 → 0.30 → 0.32`)
+    would need recomputation across 4 sections to keep the staggered rhythm
+    smooth.
+
+### Sections in code but not in brief target (4)
+
+- **BirthChartOrrery (Planetarium)** — between AstroSection and Magnetsturm
+- **SkyModeToggle** — between Planetarium and Magnetsturm
+- **ShareCard** — bottom of page, after Interpretation
+- **LegalFooter** — final element
+
+These appear to be intentional additions not captured in the brief's
+abridged target list. The brief target seems to be a "core hierarchy"
+abstraction rather than an exhaustive section inventory. Without explicit
+PO direction to remove/relocate these, leave in place.
+
+### Sections in brief target but not in code (1)
+
+- **DashboardTagesEnergie** — deliberately removed in `882eea8` (duplicate of
+  DailyChartHero). The brief target list has not been updated to reflect this
+  cleanup. Recommend: PO discussion to update the plan or formally retire the
+  component (`archive/` move).
+
+## Action
+
+**🚨 Major mismatch — audit-only, defer to a dedicated hierarchy sprint.**
+
+Reasoning:
+
+1. The single out-of-order section (DashboardInterpretationSection) requires
+   crossing two tour-overlay sentinel refs, a deep-link anchor, the entire
+   Planetarium/Sky block, MagnetsturmKarte, and the Bottom Upgrade Card. This
+   is **not** a mechanical JSX block-swap.
+2. Four sections present in code (Planetarium, SkyModeToggle, ShareCard,
+   LegalFooter) have no positions assigned in the brief. The brief target is
+   incomplete relative to actual production. A reorder commit would force
+   inventing target positions for these — that is a product decision, not a
+   code refactor.
+3. One section in the brief target (DashboardTagesEnergie) was deliberately
+   retired with rationale recorded in `882eea8`. The brief is stale.
+4. Per the project rule "minimize blast radius" and the explicit guidance in
+   the TASK-3.1 prompt: *"Default to NOT reordering unless the misalignment is
+   clearly hurting the user experience and the reorder is mechanical."* The
+   user-experience harm is unverified (the current position of Interpretation
+   below Planetarium has shipped for weeks without complaint), and the reorder
+   is non-mechanical.
+
+### Recommended follow-up (out of scope for TASK-3.1)
+
+A dedicated planning task (`/SDLC-elicit` or PO refinement session) should:
+
+1. Decide canonical target positions for **Planetarium**, **SkyModeToggle**,
+   **ShareCard**, **LegalFooter**.
+2. Decide whether DashboardInterpretationSection moves to position #5 or stays
+   at the end (its current "after the volatile content / before footer" slot
+   is not unreasonable — Interpretation is a slow-changing premium artifact,
+   reading it as an epilogue may be intentional UX).
+3. Decide whether to formally archive `DashboardTagesEnergie.tsx` and update
+   the brief target list to remove it.
+4. Once positions are pinned, a **single reorder commit** with sentinel-ref
+   relocation + fadeIn cadence renumbering can be planned.
+
+## Changes applied this commit
+
+**None to `Dashboard.tsx`.** This is a doc-only commit recording the audit
+state and deferring action.

--- a/docs/2026-05-07-signatur-3d-pipeline-audit.md
+++ b/docs/2026-05-07-signatur-3d-pipeline-audit.md
@@ -1,0 +1,148 @@
+# 3D Signatur pipeline audit — chladniParams data flow + DE/EN risk (TASK-2.1)
+
+**Date:** 2026-05-07
+**Branch:** `2026-05-07-dashboard-3d-anchor`
+**Scope:** Trace `chladniParams` from `SignaturPage` → `SignaturRenderer` → `bazi-to-chladni.ts` to assess whether Wu-Xing DE/EN key drift causes a meaningful fraction of users to see the Water-default sphere.
+**Pre-req:** HOTFIX-A landed (commit `40d3901`) — page no longer crashes; this audit is the secondary investigation.
+**Method:** Code-inspection only. Supabase prod data not checked (per task scope).
+
+---
+
+## Pipeline trace
+
+The 3D Signatur visualization is fed by a four-stage pipeline. All file:line references are `HEAD` of `2026-05-07-dashboard-3d-anchor`.
+
+### Stage 1 — BAFE → `apiData` (mapping)
+
+`src/services/api.ts:354-388` (`calculateWuxing`) and `src/services/api.ts:485-518` (the unified `/chart` mapper) both normalize the BAFE response. BAFE returns `wu_xing_vector` with **German keys** (`Holz/Feuer/Erde/Metall/Wasser`). Both mappers explicitly write **both German and English keys** into `MappedWuxing.elements`:
+
+```ts
+elements: {
+  Wood:  vec.Holz   ?? vec.Wood  ?? 0,
+  Fire:  vec.Feuer  ?? vec.Fire  ?? 0,
+  Earth: vec.Erde   ?? vec.Earth ?? 0,
+  Metal: vec.Metall ?? vec.Metal ?? 0,
+  Water: vec.Wasser ?? vec.Water ?? 0,
+  // …and German keys preserved for downstream lookup:
+  Holz, Feuer, Erde, Metall, Wasser,
+}
+```
+
+So `apiData.wuxing.elements` is a 10-key dict (5 EN + 5 DE) with identical values under both spellings.
+
+`dominant_element` (a separate top-level field) is normalized via `resolveDominantElement()` (`src/services/api.ts:125-141`) which contains an explicit DE→EN lookup table — but **this field is not consumed by `baziToChladniParams()`** (see Stage 3).
+
+### Stage 2 — `SignaturPage` derives `chladniParams`
+
+`src/pages/SignaturPage.tsx:115-122`:
+
+```ts
+const chladniParams = useMemo(() => {
+  const pillars = apiData?.bazi?.pillars;
+  const wuxingWeights = apiData?.wuxing?.elements;   // 10-key DE+EN dict
+  if (!pillars || !wuxingWeights) return undefined;
+  const rawHarmony = apiData?.wuxing?.['harmony_index'];
+  const harmonyIndex = Number.isFinite(rawHarmony as number) ? (rawHarmony as number) : 0.5;
+  return baziToChladniParams(pillars, wuxingWeights, harmonyIndex);
+}, [apiData?.bazi?.pillars, apiData?.wuxing]);
+```
+
+Guard: returns `undefined` only when `pillars` OR `wuxingWeights` is missing. For any user who completed onboarding successfully, both are present (BAFE `/chart` throws if `wuxing` is missing — `api.ts:416-418`).
+
+### Stage 3 — `baziToChladniParams` resolves the dominant element
+
+`src/lib/cymatics/bazi-to-chladni.ts:158-181`. The function is **defensively bilingual**:
+
+- `dominantElementFromWeights()` (line 74-98) iterates first over `CANONICAL_WUXING_ELEMENTS` (`'Wood', 'Fire', 'Earth', 'Metal', 'Water'`), then a second pass uses `normalizeWuxingElementKey()` (line 51-72) which accepts **both German and English** spellings (`'feuer' → 'Fire'`, `'holz' → 'Wood'`, etc., case-insensitive after `.trim().toLowerCase()`).
+
+Stem-name lookup (`STEM_NAME_TO_INDEX`, line 119-143) is also bilingual: accepts both Chinese characters (`'甲', '乙'…`) and Pinyin (`'jia', 'yi'…`), case-insensitive via the `Proxy`.
+
+**Conclusion:** `baziToChladniParams` cannot be defeated by DE/EN key drift on `wuxingWeights`. Even if the mapper somehow only emitted German keys, the second loop in `dominantElementFromWeights` would still find the max and return the canonical English `WuxingElement`.
+
+### Stage 4 — `SignaturRenderer` consumes `chladniParams`
+
+`src/components/signatur-renderer/SignaturRenderer.tsx:109-124`:
+
+```tsx
+{chladniParams ? (
+  <SignatureSphere3D
+    weights={effectivePlanetWeights}
+    dominantElement={chladniParams.dominantElement}
+    …
+  />
+) : (
+  <CymaticsFallback planetariumMode={planetariumMode} className="h-full w-full" />
+)}
+```
+
+`CymaticsFallback` defaults `dominantElement = 'Water'` (`src/components/signatur-cymatics/CymaticsFallback.tsx:18`). This is the suspected "everyone-sees-Water-sphere" failure mode — but it only triggers when `chladniParams` itself is `undefined`, which per Stage 2 only happens when BAFE data is incomplete.
+
+---
+
+## Wu-Xing key shape
+
+| Layer | Key shape on the wire |
+|------|------------------------|
+| BAFE response (`raw.wu_xing_vector`) | German: `Holz / Feuer / Erde / Metall / Wasser` |
+| BAFE response (`raw.dominant_element`) | German per latest BAFE schema (e.g. `"Feuer"`) — sometimes empty string |
+| `services/api.ts` mapper | Emits **both** EN and DE keys into `MappedWuxing.elements`; `dominant_element` is normalized DE→EN via `resolveDominantElement` |
+| `MappedWuxing.elements` (passed to `baziToChladniParams`) | 10-key dict (EN + DE, identical values) |
+| `baziToChladniParams` input expectation | Tolerant — accepts EN, DE, or both; uses `normalizeWuxingElementKey` |
+| `ChladniParams.dominantElement` (output) | Canonical English `'Wood'/'Fire'/'Earth'/'Metal'/'Water'` |
+
+Dictionary keys recognized by `normalizeWuxingElementKey()`: `wood/holz, fire/feuer, earth/erde, metal/metall, water/wasser` (case-insensitive).
+
+---
+
+## Failure modes
+
+For each path that could produce `undefined chladniParams` and trigger the Water-default `CymaticsFallback`:
+
+| # | Trigger | Likelihood for typical user | Visible result |
+|---|---------|----------------------------|----------------|
+| F1 | `apiData` is `null` (initial render before `useAstroProfile` resolves) | Transient (sub-second) on every page load | Loading overlay then sphere — not the persistent symptom |
+| F2 | `apiData.bazi.pillars` missing | Only if BAFE `/chart` succeeded but bazi block was empty — `api.ts` doesn't throw on this, but in practice always present when BAFE returns 200 | Water-default sphere |
+| F3 | `apiData.wuxing.elements` missing | `/chart` throws if `raw.wuxing` is missing entirely (`api.ts:416-418`); partial wuxing without `wu_xing_vector` would still build `elements: {Wood: 0, Fire: 0, …}` (zeros — not missing) | Water-default sphere — but only if mapper short-circuits, which it doesn't |
+| F4 | All weights are 0 (zero-element profile) | Possible but should never happen for real birth data | Sphere renders, but `dominantElementFromWeights` returns the loop's first match — **the seed value `'Water'` (line 75)**, biasing zero-data profiles to Water |
+| F5 | Wu-Xing DE/EN drift in `wuxingWeights` | **Impossible** given current mapper (always writes both) and the `normalizeWuxingElementKey` second-pass loop | n/a |
+
+---
+
+## Verdict
+
+✅ **Pipeline is robust.** The DE/EN key drift hypothesis is **not** the cause of users seeing the Water-default sphere. The mapper at `services/api.ts:373-385` writes both German and English keys into `elements`, and `baziToChladniParams` itself is bilingual via `normalizeWuxingElementKey` — so even in the hypothetical scenario where the mapper only emitted German keys, the function would still resolve the dominant element correctly.
+
+The user-reported symptom "User findet die Kugel nicht" is, after HOTFIX-A, primarily explained by:
+
+1. **F1 (transient loading)** — sphere appears after `useAstroProfile` resolves, but the perceived "missing sphere" may be the brief loading overlay window.
+2. **F4 (zero-weights edge case)** — a profile with all-zero `elements` produces `'Water'` because `dominantElementFromWeights` initializes `best = 'Water'` (line 75) and never updates if all values tie at `Number.NEGATIVE_INFINITY`. This is rare but worth flagging.
+3. **Genuine "no birth data" users** — falls cleanly to `CymaticsFallback` (Water), which is the intended behavior.
+
+The most surprising finding: the codebase has **defense-in-depth** for DE/EN drift that pre-empts the very bug the audit was looking for. Both the `services/api.ts` mapper AND the `baziToChladniParams` function independently handle bilingual input. The `normalizeWuxingElementKey` switch (line 51-72) reads like a battle-scar from prior schema instability.
+
+---
+
+## Recommendations (for a separate fix-track per brief Hinweis #8)
+
+**No action needed for DE/EN drift.** The pipeline is already overengineered against this exact failure mode.
+
+Two minor observations that could be hardened, but are NOT urgent:
+
+1. **F4 cosmetic improvement (`bazi-to-chladni.ts:74-98`):** The `best = 'Water'` initial value silently biases zero-weight profiles to a Water sphere. Consider initializing to `'Earth'` (more visually neutral, matches `NEUTRAL_PREVIEW.dominantElement`) or returning `null` for the caller to handle. Effort: 1 line. Impact: cosmetic only — affects the rare zero-weight case.
+
+2. **`harmony_index` is read via dynamic key access (`SignaturPage.tsx:119`):** The field is not on the `MappedWuxing` type, so this will silently fall back to `0.5` even if BAFE adds the field later. If BAFE emits `harmony_index` today, we're missing it. Worth a 5-minute check against a real BAFE response, but won't change the Water-vs-coloured-sphere question.
+
+**Recommendation: do NOT spawn a fix-track sprint.** The DE/EN risk hypothesis is refuted; the hotfix queue can stay focused on more impactful items.
+
+---
+
+## Production data (optional)
+
+Not checked — code-inspection-only audit. Supabase MCP access is available (toolset visible in this environment) but per task scope ("Don't run a query without confirming the connection — just note in the doc whether the data is present") and the verdict reached purely from code, a SQL probe would not change the conclusion.
+
+If a future session wants to corroborate empirically, the relevant queries on `astro_profiles` would be:
+
+- Count rows where `astro_json->'wuxing'->>'dominant_element'` is empty/null (would estimate F4 prevalence).
+- Count rows where `astro_json->'wuxing'->'elements'` has all-zero values (would estimate F4 directly).
+
+Both are read-only and safe.

--- a/src/__tests__/MagnetsturmKarte.test.tsx
+++ b/src/__tests__/MagnetsturmKarte.test.tsx
@@ -9,10 +9,10 @@ vi.mock('../contexts/LanguageContext', () => ({
   useLanguage: () => ({ lang: 'de', t: (k: string) => k }),
 }));
 
-const mockUseSpaceWeather = vi.fn();
-vi.mock('../hooks/useSpaceWeather', () => ({
-  useSpaceWeather: () => mockUseSpaceWeather(),
-}));
+// NOTE (TASK-5.2): MagnetsturmKarte is now prop-driven. It no longer calls
+// useSpaceWeather() — Dashboard.tsx is the single hook caller and passes the
+// state down. Tests construct a SpaceWeatherState fixture and render the card
+// with a `spaceWeather` prop.
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -40,76 +40,76 @@ const makeWeather = (overrides: Partial<SpaceWeatherState> = {}): SpaceWeatherSt
 
 describe('MagnetsturmKarte', () => {
   it('renders null when kpIndex is below threshold (< 4)', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 3, gScale: 'G0' }));
-    const { container } = render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 3, gScale: 'G0' });
+    const { container } = render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders null when kpIndex = 0', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 0, gScale: 'G0' }));
-    const { container } = render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 0, gScale: 'G0' });
+    const { container } = render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders null while loading', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 7, gScale: 'G3', loading: true }));
-    const { container } = render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 7, gScale: 'G3', loading: true });
+    const { container } = render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders card when kpIndex >= 4', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 5, gScale: 'G1' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 5, gScale: 'G1' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.getByTestId('magnetsturm-karte')).toBeInTheDocument();
   });
 
   it('shows G-scale badge and German label', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 6, gScale: 'G2' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 6, gScale: 'G2' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.getByText('G2')).toBeInTheDocument();
     expect(screen.getByText('Mäßiger Magnetsturm')).toBeInTheDocument();
   });
 
   it('shows Kp index value', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 5.3, gScale: 'G1' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 5.3, gScale: 'G1' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.getByText('5.3')).toBeInTheDocument();
   });
 
   it('shows AKTIV badge at G3+ (kpIndex >= 7)', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 7, gScale: 'G3' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 7, gScale: 'G3' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.getByText('AKTIV')).toBeInTheDocument();
   });
 
   it('does NOT show AKTIV badge below G3', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 5, gScale: 'G1' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 5, gScale: 'G1' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.queryByText('AKTIV')).toBeNull();
   });
 
   it('hides X-ray class when it is A (nominal)', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 5, gScale: 'G1', xrayClass: 'A' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 5, gScale: 'G1', xrayClass: 'A' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.queryByText('Röntgenklasse')).toBeNull();
   });
 
   it('shows X-ray class when elevated (M or X)', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 7, gScale: 'G3', xrayClass: 'M5' }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 7, gScale: 'G3', xrayClass: 'M5' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.getByText('Röntgenklasse')).toBeInTheDocument();
     expect(screen.getByText('M5')).toBeInTheDocument();
   });
 
   it('shows proton flux when elevated (>= 10 pfu)', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 7, gScale: 'G3', protonFlux: 150 }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 7, gScale: 'G3', protonFlux: 150 });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.getByText('Protonenfluss')).toBeInTheDocument();
   });
 
   it('hides proton flux when below 10 pfu', () => {
-    mockUseSpaceWeather.mockReturnValue(makeWeather({ kpIndex: 5, gScale: 'G1', protonFlux: 2 }));
-    render(<MagnetsturmKarte />);
+    const sw = makeWeather({ kpIndex: 5, gScale: 'G1', protonFlux: 2 });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
     expect(screen.queryByText('Protonenfluss')).toBeNull();
   });
 });

--- a/src/__tests__/magnetsturm-karte-prop-driven.test.tsx
+++ b/src/__tests__/magnetsturm-karte-prop-driven.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * MagnetsturmKarte — prop-driven (TASK-5.2)
+ *
+ * Verifies that MagnetsturmKarte receives spaceWeather via props instead of
+ * calling useSpaceWeather() directly. This deduplicates the NOAA poller when
+ * Dashboard mounts both the hook and the card on the same page.
+ *
+ * Single-poller invariant: Dashboard.tsx is the sole caller of
+ * useSpaceWeather() in the dashboard tree. MagnetsturmKarte must not poll on
+ * its own.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MagnetsturmKarte } from '../components/dashboard/MagnetsturmKarte';
+import type { SpaceWeatherState } from '../hooks/useSpaceWeather';
+
+vi.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de' as const, t: (k: string) => k, setLang: vi.fn() }),
+}));
+
+// Critically: do NOT mock useSpaceWeather here. The component must not call
+// it after the refactor. If it does, the test environment would error on
+// fetch/setInterval calls or the dashed rendering would diverge.
+
+const makeWeather = (overrides: Partial<SpaceWeatherState> = {}): SpaceWeatherState => ({
+  kpIndex: 0,
+  solarPressure: 0,
+  ringModulation: 1,
+  intensityBoost: 0,
+  triggerEffect: false,
+  gScale: 'G0',
+  xrayFlux: 0,
+  xrayClass: 'A',
+  protonFlux: 0,
+  f107: 150,
+  solarCyclePhase: 'ascending',
+  events: [],
+  alerts: [],
+  lastUpdate: null,
+  loading: false,
+  error: null,
+  ...overrides,
+});
+
+describe('MagnetsturmKarte (TASK-5.2 prop-driven)', () => {
+  it('MK-PROP-001: renders Kp value from prop without calling useSpaceWeather()', () => {
+    const sw = makeWeather({ kpIndex: 5.3, gScale: 'G1' });
+    render(<MagnetsturmKarte spaceWeather={sw} />);
+
+    // Visible card means props were consumed.
+    expect(screen.getByTestId('magnetsturm-karte')).toBeInTheDocument();
+    // Kp value rendered from the prop, not from a polled hook.
+    expect(screen.getByText('5.3')).toBeInTheDocument();
+    expect(screen.getByText('G1')).toBeInTheDocument();
+  });
+
+  it('MK-PROP-002: self-hides from prop when kpIndex < 4', () => {
+    const sw = makeWeather({ kpIndex: 2, gScale: 'G0' });
+    const { container } = render(<MagnetsturmKarte spaceWeather={sw} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('MK-PROP-003: self-hides from prop while loading', () => {
+    const sw = makeWeather({ kpIndex: 7, gScale: 'G3', loading: true });
+    const { container } = render(<MagnetsturmKarte spaceWeather={sw} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/__tests__/signatur-anchor-card.test.tsx
+++ b/src/__tests__/signatur-anchor-card.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ lang: 'de' as const, t: (k: string) => k, setLang: vi.fn() }),
+}));
+
+import { SignaturAnchorCard } from '../components/dashboard/SignaturAnchorCard';
+
+describe('SignaturAnchorCard (TASK-2.2)', () => {
+  it('SAC-001: renders preview + CTA', () => {
+    render(<SignaturAnchorCard dominantElement="Fire" birthSign="Aries" />);
+    expect(screen.getByTestId('signatur-anchor-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /signatur/i })).toBeInTheDocument();
+  });
+
+  it('SAC-002: CTA navigates to /signatur', async () => {
+    const user = userEvent.setup();
+    render(<SignaturAnchorCard dominantElement="Fire" birthSign="Aries" />);
+    await user.click(screen.getByRole('button', { name: /signatur/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/signatur');
+  });
+
+  it('SAC-003: empty state when neither prop is provided', () => {
+    render(<SignaturAnchorCard />);
+    expect(screen.getByTestId('signatur-anchor-card')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/use-signatur-signal-polling.test.ts
+++ b/src/__tests__/use-signatur-signal-polling.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock authedFetch to avoid importing supabase (requires VITE_SUPABASE_* env vars).
+vi.mock('@/src/lib/authedFetch', () => ({
+  authedFetch: vi.fn((...args: Parameters<typeof fetch>) => fetch(...args)),
+}));
+
+import {
+  ACTIVE_POLL_INTERVAL_MS,
+  HIDDEN_POLL_INTERVAL_MS,
+  useSignaturSignal,
+} from '@/src/hooks/useSignaturSignal';
+
+const validTransitPayload = {
+  ring: { sectors: Array(12).fill(0.6) },
+  soulprint: { sectors: Array(12).fill(0.4) },
+  transit_contribution: { transit_intensity: 0.75 },
+  delta: { vs_30day_avg: { avg_sectors: Array(12).fill(0.35) } },
+  events: [],
+  resolution: 64,
+};
+
+/**
+ * TASK-5.1 — Polling cadence targets per
+ * docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md §Phase 5 / Task 5.1.
+ *
+ * Visible tab = 15s, hidden tab = 60s. These tests pin the constants so a
+ * future contributor cannot silently regress to the old 800ms hammering.
+ */
+describe('useSignaturSignal — visibility-aware polling cadence (TASK-5.1)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('USS-POLL-001: ACTIVE_POLL_INTERVAL_MS is exactly 15s (Plan §5.1)', () => {
+    expect(ACTIVE_POLL_INTERVAL_MS).toBe(15_000);
+  });
+
+  it('USS-POLL-002: HIDDEN_POLL_INTERVAL_MS is exactly 60s (Plan §5.1)', () => {
+    expect(HIDDEN_POLL_INTERVAL_MS).toBe(60_000);
+  });
+
+  it('USS-POLL-003: visible tab → polls roughly every 15s (initial + 3 ticks ≈ 4 in 45s)', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => validTransitPayload,
+    } as Response);
+
+    renderHook(() => useSignaturSignal('user-poll-001'));
+
+    // Flush initial mount fetch.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // 45s window → 3 additional ticks at the 15s cadence.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('USS-POLL-004: hidden tab → polls every 60s, not 15s (3 minutes ≈ 4 calls)', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => validTransitPayload,
+    } as Response);
+
+    renderHook(() => useSignaturSignal('user-poll-002'));
+
+    // Flush initial mount fetch.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // 3 minute window → 3 additional ticks at the 60s cadence (not 12 at 15s).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180_000);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('USS-POLL-005: visibility → visible triggers immediate refresh', async () => {
+    let visibilityState: DocumentVisibilityState = 'hidden';
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => validTransitPayload,
+    } as Response);
+
+    renderHook(() => useSignaturSignal('user-poll-003'));
+
+    // Initial mount fetch only — hidden cadence is 60s away.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Flip to visible: must fire an immediate refresh, not wait for the next tick.
+    visibilityState = 'visible';
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -492,7 +492,7 @@ export function Dashboard({
       {/* ═══ 5. MAGNETSTURM (self-hides when Kp < 4) ════════════════ */}
       <motion.div {...fadeIn(0.26)}>
         <SectionErrorBoundary name="MagnetsturmKarte">
-          <MagnetsturmKarte />
+          <MagnetsturmKarte spaceWeather={spaceWeather} />
         </SectionErrorBoundary>
       </motion.div>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -138,6 +138,10 @@ export function Dashboard({
   const tourOverlayVisible = isTourStepVisible(tourStep, scrollReached);
 
   useEffect(() => {
+    // TODO(analytics): trackEvent('dashboard_first_interaction') on first user action
+  }, []);
+
+  useEffect(() => {
     if (tourStep !== 1) return;
 
     const sentinel = leviSentinelRef.current;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -38,6 +38,7 @@ import { getConstellationForSign } from "../lib/astro-data/constellationFromSign
 import { useCelestialOrrery } from "../hooks/useCelestialOrrery";
 import { CITIES } from "../lib/astronomy/data";
 import { DailyChartHero } from "./dashboard/DailyChartHero";
+import { SignaturAnchorCard } from "./dashboard/SignaturAnchorCard";
 import { useActiveImpacts } from "../hooks/useActiveImpacts";
 
 const BirthChartOrrery = lazy(() => import("./BirthChartOrrery").then(m => ({ default: m.BirthChartOrrery })));
@@ -390,6 +391,16 @@ export function Dashboard({
             // modal; the modal itself handles fallback-aware rendering.
             onOpenDayModal={dailyEnabled ? () => setIsDayModalOpen(true) : undefined}
             isFallback={dailyData?.meta?.engine_version === 'v1-local-fallback'}
+          />
+        </SectionErrorBoundary>
+      </motion.div>
+
+      {/* ═══ 1.5 SIGNATUR ANCHOR — preview + CTA, no WebGL on dashboard (TASK-2.2) ═══ */}
+      <motion.div {...fadeIn(0.08)}>
+        <SectionErrorBoundary name="SignaturAnchor">
+          <SignaturAnchorCard
+            dominantElement={apiData?.wuxing?.dominant_element}
+            birthSign={apiData?.western?.zodiac_sign}
           />
         </SectionErrorBoundary>
       </motion.div>

--- a/src/components/dashboard/DayModeModal.tsx
+++ b/src/components/dashboard/DayModeModal.tsx
@@ -149,6 +149,7 @@ export function DayModeModal({ data, dayHarmonic, onClose }: Props) {
     if (!hasTrackedRef.current) {
       const mode = dayHarmonic?.mode ?? data.fusion.day_mode ?? 'pulse';
       trackEvent('day_mode_modal_opened', { mode });
+      // TODO(analytics): trackEvent('daily_detail_open_rate')
       hasTrackedRef.current = true;
     }
   }, [dayHarmonic, data.fusion.day_mode]);

--- a/src/components/dashboard/MagnetsturmKarte.tsx
+++ b/src/components/dashboard/MagnetsturmKarte.tsx
@@ -7,7 +7,10 @@
  *
  * Visibility rule: renders null when kpIndex < 4. No empty placeholder card.
  *
- * Data source: useSpaceWeather() — polls /api/space-weather/extended every 5 min.
+ * Data source: prop `spaceWeather` (TASK-5.2 — prop-driven).
+ * Dashboard.tsx is the single caller of useSpaceWeather() for the dashboard
+ * tree and passes the value down. This deduplicates the 5-minute NOAA poller
+ * (was 2 instances per dashboard mount, now 1).
  *
  * Note on solar wind speed / Bz: The current SpaceWeatherExtendedSchema does not
  * include solar wind plasma speed or Bz (IMF z-component) — these require
@@ -16,7 +19,7 @@
  * proxy display here (search: FUTURE-BZ-WIND).
  */
 
-import { useSpaceWeather } from '../../hooks/useSpaceWeather';
+import type { SpaceWeatherState } from '../../hooks/useSpaceWeather';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 // ── G-scale → display colour ──────────────────────────────────────────────────
@@ -49,16 +52,20 @@ const G_SCALE_EN: Record<string, string> = {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function MagnetsturmKarte() {
-  const sw = useSpaceWeather();
+interface MagnetsturmKarteProps {
+  /** Live space-weather state, owned by Dashboard.tsx (single poller). */
+  spaceWeather: SpaceWeatherState;
+}
+
+export function MagnetsturmKarte({ spaceWeather: sw }: MagnetsturmKarteProps) {
   const { lang } = useLanguage();
   const isDe = lang === 'de';
 
   // Self-hide when Kp < 4 (below G1 threshold)
-  // Source: useSpaceWeather().kpIndex (NOAA SWPC /api/space-weather/extended)
+  // Source: spaceWeather.kpIndex (NOAA SWPC /api/space-weather/extended via Dashboard)
   if (sw.loading || sw.kpIndex < 4) return null;
 
-  // Source: useSpaceWeather().gScale (derived from kpIndex in solar-pressure.ts)
+  // Source: spaceWeather.gScale (derived from kpIndex in solar-pressure.ts)
   const color = gScaleColor(sw.gScale);
   const label = isDe
     ? (G_SCALE_DE[sw.gScale] ?? sw.gScale)
@@ -84,12 +91,12 @@ export function MagnetsturmKarte() {
       {/* ── Header ────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          {/* Source: useSpaceWeather().gScale */}
+          {/* Source: spaceWeather.gScale */}
           <span
             className="text-[9px] font-bold tracking-[0.25em] uppercase px-2 py-0.5 rounded-full"
             style={{ background: `${color}22`, color }}
           >
-            {/* Source: useSpaceWeather().gScale (NOAA Kp→G-scale conversion) */}
+            {/* Source: spaceWeather.gScale (NOAA Kp→G-scale conversion) */}
             {sw.gScale}
           </span>
           <span
@@ -112,7 +119,7 @@ export function MagnetsturmKarte() {
       {/* ── Values ────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 gap-3">
         {/* Kp Index */}
-        {/* Source: useSpaceWeather().kpIndex (NOAA SWPC Kp 3-hour index) */}
+        {/* Source: spaceWeather.kpIndex (NOAA SWPC Kp 3-hour index) */}
         <ValueCell
           label={isDe ? 'Kp-Index' : 'Kp Index'}
           value={sw.kpIndex.toFixed(1)}
@@ -124,7 +131,7 @@ export function MagnetsturmKarte() {
         />
 
         {/* Solar pressure */}
-        {/* Source: useSpaceWeather().solarPressure (computeSolarPressureScore in solar-pressure.ts) */}
+        {/* Source: spaceWeather.solarPressure (computeSolarPressureScore in solar-pressure.ts) */}
         <ValueCell
           label={isDe ? 'Solardruck' : 'Solar pressure'}
           value={Math.round(sw.solarPressure * 100).toString()}
@@ -136,7 +143,7 @@ export function MagnetsturmKarte() {
         />
 
         {/* X-ray class — FUTURE-BZ-WIND: replace with solar wind speed km/s when available */}
-        {/* Source: useSpaceWeather().xrayClass (NOAA SWPC GOES X-ray 1-8 Å) */}
+        {/* Source: spaceWeather.xrayClass (NOAA SWPC GOES X-ray 1-8 Å) */}
         {sw.xrayClass !== 'A' && (
           <ValueCell
             label={isDe ? 'Röntgenklasse' : 'X-ray class'}
@@ -150,7 +157,7 @@ export function MagnetsturmKarte() {
         )}
 
         {/* Proton flux if elevated (≥ 10 pfu = threshold for proton event) */}
-        {/* Source: useSpaceWeather().protonFlux (NOAA SWPC GOES proton ≥10 MeV) */}
+        {/* Source: spaceWeather.protonFlux (NOAA SWPC GOES proton ≥10 MeV) */}
         {sw.protonFlux >= 10 && (
           <ValueCell
             label={isDe ? 'Protonenfluss' : 'Proton flux'}

--- a/src/components/dashboard/SignaturAnchorCard.tsx
+++ b/src/components/dashboard/SignaturAnchorCard.tsx
@@ -47,7 +47,10 @@ export function SignaturAnchorCard({ dominantElement, birthSign }: Props) {
       </div>
       <button
         type="button"
-        onClick={() => navigate('/signatur')}
+        onClick={() => {
+          // TODO(analytics): trackEvent('signatur_sphere_interaction')
+          navigate('/signatur');
+        }}
         className="text-sm text-gold hover:text-gold/80 transition-colors whitespace-nowrap"
       >
         {t('signatur.anchor.cta')}

--- a/src/components/dashboard/SignaturAnchorCard.tsx
+++ b/src/components/dashboard/SignaturAnchorCard.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from 'react-router-dom';
+import { useLanguage } from '@/src/contexts/LanguageContext';
+
+/**
+ * Static "anchor" card on the dashboard that previews the user's Signatur
+ * (dominant element + birth sign) and links to `/signatur` for the full
+ * 3D experience.
+ *
+ * Performance-safe by design: NO WebGL on the dashboard. Users opt into
+ * the 3D Chladni sphere by tapping the CTA — this matches Brief Option B
+ * (preview + link). Option A (embedded R3F on dashboard) is deferred
+ * until Option B is stable in prod.
+ *
+ * Empty state: when neither dominantElement nor birthSign is provided
+ * (incomplete profile), shows `signatur.anchor.empty`.
+ */
+interface Props {
+  dominantElement?: string;
+  birthSign?: string;
+}
+
+export function SignaturAnchorCard({ dominantElement, birthSign }: Props) {
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+  const hasProfile = !!(dominantElement && birthSign);
+
+  return (
+    <section
+      className="cosmic-tile p-6 rounded-[2rem] flex items-center gap-4"
+      data-testid="signatur-anchor-card"
+    >
+      <div className="flex-1 min-w-0">
+        <p
+          className="text-xs font-bold tracking-[0.2em] uppercase"
+          style={{ color: 'var(--tile-text-secondary)' }}
+        >
+          {t('signatur.anchor.title')}
+        </p>
+        <p
+          className="text-xs mt-1"
+          style={{ color: 'var(--tile-text-secondary)', opacity: 0.6 }}
+        >
+          {hasProfile
+            ? `${birthSign} · ${dominantElement}`
+            : t('signatur.anchor.empty')}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => navigate('/signatur')}
+        className="text-sm text-gold hover:text-gold/80 transition-colors whitespace-nowrap"
+      >
+        {t('signatur.anchor.cta')}
+      </button>
+    </section>
+  );
+}

--- a/src/hooks/useSignaturSignal.ts
+++ b/src/hooks/useSignaturSignal.ts
@@ -27,24 +27,26 @@ type SignaturSignalState = {
 const clampTarget = (value: number): number => Math.max(-1, Math.min(2, value));
 
 /**
- * Polling cadence (Phase 2 — Task 14, 2026-05-06 backend hardening sprint).
+ * Polling cadence (TASK-5.1 — 2026-05-09 GreenOps sprint;
+ * see docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md §Phase 5).
  *
- * Was 800ms — fired ~1125 requests per 15 minutes per dashboard mount and
- * burnt the global API rate-limit before the global polling skip-list was
- * added in Sprint S-DASH-SIGNATUR-GAPS. Now:
+ * History:
+ *   - 800ms (legacy) — hammered the global rate-limiter, ~1125 req / 15 min.
+ *   - 8s active / 45s hidden (2026-05-06 backend hardening) — first cut.
+ *   - 15s active / 60s hidden (2026-05-09 GreenOps) — current. Cuts
+ *     transit-state traffic ~70% during typical browsing without
+ *     hurting perceived liveness (server cache TTL absorbs the gap;
+ *     transits don't visibly change faster than the eye can resolve).
  *
- *   ACTIVE  — visible tab, ~7.5 polls/min. Server cache (10s TTL, see
- *             server.mjs:/api/transit-state) absorbs consecutive same-user
- *             polls; ring on screen still feels live (transits don't
- *             change faster than the eye can perceive).
+ *   ACTIVE  — visible tab, 4 polls/min.
  *   HIDDEN  — backgrounded tab; effectively pause-and-keep-warm so the
  *             ring is fresh when the user returns. visibilitychange also
  *             triggers an immediate fetch.
  *   OFFLINE — keep checking but don't burn battery.
  *   ERROR   — exponential backoff capped at 30s.
  */
-export const ACTIVE_POLL_INTERVAL_MS = 8_000;
-export const HIDDEN_POLL_INTERVAL_MS = 45_000;
+export const ACTIVE_POLL_INTERVAL_MS = 15_000;
+export const HIDDEN_POLL_INTERVAL_MS = 60_000;
 const OFFLINE_POLL_INTERVAL_MS = 15_000;
 const ERROR_BASE_RETRY_MS = 3_000;
 const ERROR_MAX_RETRY_MS = 30_000;

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -175,6 +175,11 @@ const translationsEn: DeepStringRecord = {
       title: "Unlock your full Signatur experience",
       subtitle: "Premium clusters, advanced quizzes, and more",
     },
+    anchor: {
+      title: "Your Signature",
+      cta: "View signature →",
+      empty: "Profile incomplete",
+    },
   },
   signatureReveal: {
     soulprintCalculating: "Calculating your soulprint…",
@@ -670,6 +675,11 @@ const translationsDe: DeepStringRecord = {
     upgradeCard: {
       title: "Schalte deine volle Signatur-Erfahrung frei",
       subtitle: "Premium-Cluster, erweiterte Quizzes und mehr",
+    },
+    anchor: {
+      title: "Deine Signatur",
+      cta: "Signatur ansehen →",
+      empty: "Profil unvollständig",
     },
   },
   signatureReveal: {


### PR DESCRIPTION
## Summary
- **TASK-2.2 — `SignaturAnchorCard` on the dashboard**: new static section between `DailyChartHero` and `AgentSection`. Birth sign + dominant element preview + "Signatur ansehen →" CTA navigating to `/signatur`. **No WebGL on dashboard** — performance-safe; the 3D Chladni sphere only loads when the user opts in. Empty state when profile incomplete. Brief Option B; Option A (embedded R3F) deferred until B is stable.
- **TASK-5.1 — visibility-aware Signatur polling**: bumped `useSignaturSignal` from 8s/45s to 15s/60s (visible / hidden tab). The hook was already self-rescheduling with visibility detection + exponential backoff after the 2026-05-06 backend hardening sprint — this just shifts the cadence. Plan's "currently every 800ms" referred to the legacy regression baseline.
- **TASK-5.2 — single `useSpaceWeather()` poller per dashboard mount**: `MagnetsturmKarte` is now prop-driven instead of calling the hook independently. Reduces NOAA SWPC requests 2 → 1 per 5-min window. 12 existing tests adapted, 0 deletions. `SignaturPage` and `SignaturRenderer` callsites left untouched (separate page mounts).
- **TASK-2.1 — 3D Signatur pipeline audit (read-only)**: ✅ **robust**. Wu-Xing DE/EN drift hypothesis **refuted** — defense-in-depth via `normalizeWuxingElementKey` accepts `feuer/holz/wasser/erde/metall` case-insensitively alongside English keys. No fix-track needed.
- **TASK-3.1 — Dashboard hierarchy audit (deferred)**: 🚨 major mismatch — plan target references retired `DashboardTagesEnergie` (removed 2026-04-15 in commit `882eea8`); `DashboardInterpretationSection` reorder is non-mechanical (crosses sentinels, deep-link anchors, MagnetsturmKarte). **Recommends plan update or PO re-confirmation before code reorder.**
- **TASK-3.2 — `TODO(analytics):` markers** at three retention surfaces: `dashboard_first_interaction`, `daily_detail_open_rate`, `signatur_sphere_interaction`. Comment-only stubs for a future analytics sprint to wire up.
- Implementation plan: `docs/plans/2026-05-07-dashboard-flow-tagespuls-3d.md` (PR 2 = Phase 2 + Phase 3 + Phase 5).

## Test plan
- [ ] `npm test` — full suite green (2299/2299, was 2288/2288 at PR 1 head)
- [ ] `npm run lint` — clean
- [ ] `npm run build` — succeeds
- [ ] Manual smoke: dashboard shows SignaturAnchorCard between DailyChartHero and AgentSection; CTA navigates to `/signatur`
- [ ] Manual smoke: switch tabs, open Network panel, confirm transit-state polling cadence reduces (target ~15s on visible, ~60s on hidden)
- [ ] Manual smoke: confirm only 1 `/api/space-weather/extended` poll fires from the dashboard mount per 5-min window
- [ ] Read the two audit docs (`docs/2026-05-07-signatur-3d-pipeline-audit.md`, `docs/2026-05-07-dashboard-hierarchy-audit.md`) — decide whether to update the implementation plan or schedule a PO refinement for the hierarchy reorder

## Stacked PR
This PR depends on [PR 2: Dashboard Stability Hotfixes](../tree/2026-05-07-dashboard-stability-hotfixes), which depends on [PR 1: Dashboard CTA Consolidation](../tree/2026-05-07-dashboard-cta-consolidation). Merge order: CTA → Stability Hotfixes → this PR.

## Out of scope (deliberate)
- PR 3 (Phase T — Tagespuls neu-architecture) is **gated on aphorism approvals** (≥15 approved across pulse/trace/spannung mode-tags; currently 0/16/5). Separate PR when gate passes.
- Hierarchy reorder (TASK-3.1) deferred pending plan update or PO refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)