### PR TITLE
Tagespuls follow-up: address PR #335 review findings (I-1..I-4 + M-1, M-3, M-5)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -3283,15 +3283,37 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
       return res.status(404).json({ error: { code: 'PULSE_NOT_FOUND' } });
     }
 
-    // C-3 short-circuit (audit follow-up I-1): existing-row check FIRST,
-    // before the profile reload. Most requests after first pick are
-    // page-reloads / re-mounts that hit the cache or the lock; in those
-    // cases we don't need to load the profile at all.
-    const { data: existing } = await supabaseServer
+    // C-3 short-circuit (audit follow-up I-1, I-3): existing-row check
+    // FIRST, before the profile reload. Most requests after first pick
+    // are page-reloads / re-mounts that hit the cache or the lock; in
+    // those cases we don't need to load the profile at all.
+    //
+    // I-3 (locale-switching loophole): query interpretations across ALL
+    // of this user's pulses for (user_id, date), not just the requested
+    // pulse_id. Without this, a user could pick on locale=de, switch to
+    // locale=en (which uses a different daily_pulse_id by design — pulses
+    // are keyed (user_id, date, locale)), and pick again — getting two
+    // decisions on the same Kalendertag. Spec C-3 forbids that.
+    //
+    // Step 1: collect all pulse_ids for this user on this date.
+    const { data: pulsesForDate } = await supabaseServer
+      .from('daily_pulses')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('date', pulse.date);
+    const pulseIdsForDate = (pulsesForDate ?? []).map((p) => p.id);
+
+    // Step 2: find the first interpretation (if any) across those pulses.
+    // .order('created_at') + .limit(1) implements "first decision wins"
+    // semantics, consistent with the migration cleanup that resolved
+    // historic loophole-victim rows.
+    const { data: existingList } = await supabaseServer
       .from('daily_interpretations')
-      .select('id, text, selected_archetype_key, locale')
-      .eq('daily_pulse_id', dailyPulseId)
-      .maybeSingle();
+      .select('id, text, selected_archetype_key, locale, daily_pulse_id')
+      .in('daily_pulse_id', pulseIdsForDate)
+      .order('created_at', { ascending: true })
+      .limit(1);
+    const existing = existingList?.[0] ?? null;
     if (existing) {
       // Same archetype + same locale = idempotent re-pick (page reload,
       // double-click) — return 200 with the cached row.

--- a/server.mjs
+++ b/server.mjs
@@ -3283,29 +3283,10 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
       return res.status(404).json({ error: { code: 'PULSE_NOT_FOUND' } });
     }
 
-    // C-1 (2026-05-09 audit): reload astro_profiles so the prompt
-    // builder can name the user's ACTUAL sign/element for the chosen
-    // archetype — not just the archetype key. Without this, the LLM
-    // would have to invent the sign (hallucination) or stay generic
-    // (no value over slot_2/3).
-    const { data: profileRow } = await supabaseServer
-      .from('astro_profiles')
-      .select('astro_json')
-      .eq('user_id', userId)
-      .maybeSingle();
-    if (!profileRow?.astro_json || Object.keys(profileRow.astro_json).length === 0) {
-      // Profile was deleted or zeroed between pulse-creation and now.
-      // 422 forces the client to re-onboard — cleaner than 503.
-      return res.status(422).json({ error: { code: 'PROFILE_REQUIRED' } });
-    }
-    const interpretationCouncil = buildCouncilFromProfile(profileRow.astro_json);
-    const archetypeMatch = interpretationCouncil.find((c) => c.key === archetypeKey);
-    const signOrElement = archetypeMatch?.signOrElement ?? null;
-
-    // L2: at most one decision per daily_pulse_id (enforced by
-    // unique constraint daily_interpretations_one_per_pulse, mirrored
-    // here so the server returns a structured 409 instead of leaking
-    // a Postgres unique-violation error). Per 2026-05-09 audit C-3.
+    // C-3 short-circuit (audit follow-up I-1): existing-row check FIRST,
+    // before the profile reload. Most requests after first pick are
+    // page-reloads / re-mounts that hit the cache or the lock; in those
+    // cases we don't need to load the profile at all.
     const { data: existing } = await supabaseServer
       .from('daily_interpretations')
       .select('id, text, selected_archetype_key, locale')
@@ -3324,11 +3305,32 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
         error: {
           code: 'ALREADY_DECIDED',
           locked_archetype_key: existing.selected_archetype_key,
-          locked_locale: existing.locale,
           text: existing.text,
         },
       });
     }
+
+    // C-1 (2026-05-09 audit): reload astro_profiles so the prompt
+    // builder can name the user's ACTUAL sign/element for the chosen
+    // archetype — not just the archetype key. Without this, the LLM
+    // would have to invent the sign (hallucination) or stay generic
+    // (no value over slot_2/3). Reordered after the existing-row check
+    // (audit follow-up I-1) so cache hits skip this DB roundtrip.
+    const { data: profileRow } = await supabaseServer
+      .from('astro_profiles')
+      .select('astro_json')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (!profileRow?.astro_json || Object.keys(profileRow.astro_json).length === 0) {
+      // Rare race window: daily_pulse exists (so /api/daily-pulse
+      // already loaded the profile successfully), but the profile was
+      // deleted/zeroed between then and this call. 422 forces the
+      // client to re-onboard — cleaner than 503.
+      return res.status(422).json({ error: { code: 'PROFILE_REQUIRED' } });
+    }
+    const interpretationCouncil = buildCouncilFromProfile(profileRow.astro_json);
+    const archetypeMatch = interpretationCouncil.find((c) => c.key === archetypeKey);
+    const signOrElement = archetypeMatch?.signOrElement ?? null;
 
     if (!geminiClient) {
       return res.status(503).json({ error: { code: 'AI_UNAVAILABLE', retry_after: 300 } });
@@ -3369,7 +3371,30 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
       .single();
 
     if (insErr || !row) {
-      console.error('[daily-interpretation] Persist failed:', insErr?.message);
+      // Audit follow-up I-2: race-condition victim. Between our
+      // pre-check and this insert, a concurrent request snuck in and
+      // created the row. The unique constraint
+      // daily_interpretations_one_per_pulse rejects us with Postgres
+      // 23505. Re-fetch the winning row and return 409 with the same
+      // envelope shape as the pre-check path — race-losers get the
+      // same UX as pre-check-hits, not a generic 500.
+      if (insErr?.code === '23505') {
+        const { data: winner } = await supabaseServer
+          .from('daily_interpretations')
+          .select('id, text, selected_archetype_key')
+          .eq('daily_pulse_id', dailyPulseId)
+          .maybeSingle();
+        if (winner) {
+          return res.status(409).json({
+            error: {
+              code: 'ALREADY_DECIDED',
+              locked_archetype_key: winner.selected_archetype_key,
+              text: winner.text,
+            },
+          });
+        }
+      }
+      console.error('[daily-interpretation] Persist failed:', insErr?.code || insErr?.message);
       return res.status(500).json({ error: { code: 'PERSIST_FAILED' } });
     }
 

--- a/server.mjs
+++ b/server.mjs
@@ -3344,10 +3344,14 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
       .eq('user_id', userId)
       .maybeSingle();
     if (!profileRow?.astro_json || Object.keys(profileRow.astro_json).length === 0) {
-      // Rare race window: daily_pulse exists (so /api/daily-pulse
-      // already loaded the profile successfully), but the profile was
-      // deleted/zeroed between then and this call. 422 forces the
-      // client to re-onboard — cleaner than 503.
+      // M-3: Near-impossible race window. /api/daily-pulse already
+      // loaded the profile successfully (otherwise this request's
+      // pulse_id couldn't exist). Reaching this 422 means the profile
+      // was deleted/zeroed BETWEEN the pulse-create call and this
+      // interpretation call — typically a deliberate user action
+      // (e.g., "reset my chart" between picking the figure and
+      // submitting). 422 forces the client to re-onboard rather than
+      // surfacing a confusing 503 or generic 500.
       return res.status(422).json({ error: { code: 'PROFILE_REQUIRED' } });
     }
     const interpretationCouncil = buildCouncilFromProfile(profileRow.astro_json);
@@ -3416,6 +3420,12 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
           });
         }
       }
+      // M-5: prefer Postgres `code` over `message` to avoid logging
+      // row data that the message field MIGHT contain. Supabase JS
+      // errors don't typically carry user content in `message` (they
+      // surface PG codes like 23505, 23503, etc.), but `code || message`
+      // is belt-and-braces. If a future Supabase change exposes more in
+      // `message`, swap to redactLog(insErr) from server/utils/redact.mjs.
       console.error('[daily-interpretation] Persist failed:', insErr?.code || insErr?.message);
       return res.status(500).json({ error: { code: 'PERSIST_FAILED' } });
     }

--- a/server/__tests__/daily-interpretation.test.mjs
+++ b/server/__tests__/daily-interpretation.test.mjs
@@ -620,4 +620,165 @@ describe('POST /api/daily-interpretation — no-placeholders contract', () => {
     // The pre-check GET fired once + the race-recovery re-fetch GET fired once = 2 total.
     expect(interpretationGetCount).toBe(2);
   });
+
+  it('DIN-LOOPHOLE-001: user has DE decision, EN pick for same Kalendertag returns 409 (cross-locale lock)', async () => {
+    // Audit follow-up I-3: daily_pulses are keyed (user_id, date, locale)
+    // so a user switching locale gets a NEW pulse_id. Without a
+    // (user_id, date)-scoped lock, they could pick again — getting two
+    // decisions on the same Kalendertag, violating spec C-3.
+    //
+    // Setup: user has TWO pulses today (pulse-de, pulse-en). User
+    // already picked 'mond' on the DE pulse. Now they call the EN
+    // endpoint with archetype='sonne'. Server must scope the lock by
+    // (user, date), find the DE 'mond' decision, return 409.
+
+    const dePulse = { ...PULSE_ROW, id: 'pulse-de', locale: 'de' };
+    const enPulse = { ...PULSE_ROW, id: 'pulse-en', locale: 'en' };
+    const lockedDeRow = {
+      id: 'int-locked-de',
+      text: 'Mond DE locked text',
+      selected_archetype_key: 'mond',
+      locale: 'de',
+      daily_pulse_id: 'pulse-de',
+    };
+
+    let dailyPulsesGetCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input
+        : input instanceof URL ? input.toString()
+          : input?.url ?? '';
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.includes('auth/v1/user')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ id: 'user-1', email: 't@test.com', aud: 'authenticated' }),
+          text: async () => JSON.stringify({ id: 'user-1' }),
+        };
+      }
+      if (url.includes('/daily_pulses')) {
+        dailyPulsesGetCount += 1;
+        // 1st call: auth-boundary lookup (eq id, eq user_id) — request
+        //           hits EN pulse, return that.
+        // 2nd call: per-date scope lookup (eq user_id, eq date) — return
+        //           BOTH pulses so the loophole-victim DE row is reachable.
+        const data = dailyPulsesGetCount === 1 ? [enPulse] : [dePulse, enPulse];
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => data,
+          text: async () => JSON.stringify(data),
+        };
+      }
+      if (url.includes('/daily_interpretations')) {
+        // .in('daily_pulse_id', ['pulse-de','pulse-en']).order().limit(1)
+        // → returns earliest = the DE row
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => [lockedDeRow],
+          text: async () => JSON.stringify([lockedDeRow]),
+        };
+      }
+      // astro_profiles, etc. — should NOT be hit (lock short-circuits).
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({}),
+        text: async () => '{}',
+      };
+    });
+
+    const geminiClass = makeGeminiTextMock('SHOULD NOT BE CALLED — CROSS-LOCALE LOCK');
+    const app = await loadApp(geminiClass);
+
+    const res = await request(app)
+      .post('/api/daily-interpretation')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send({
+        daily_pulse_id: 'pulse-en',
+        selected_archetype_key: 'sonne',
+        locale: 'en',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error?.code).toBe('ALREADY_DECIDED');
+    expect(res.body?.error?.locked_archetype_key).toBe('mond');
+    expect(res.body?.error?.text).toBe('Mond DE locked text');
+  });
+
+  it('DIN-LOOPHOLE-002: same archetype, different locale → 409 (locked text in original locale)', async () => {
+    // Edge case: user has 'mond DE' decision, switches to EN, picks
+    // 'mond' again. Same archetype but different locale. Per spec
+    // C-3 ("first decision wins"), this is locked — user sees their
+    // original DE text, not a fresh EN re-translation.
+    const dePulse = { ...PULSE_ROW, id: 'pulse-de', locale: 'de' };
+    const enPulse = { ...PULSE_ROW, id: 'pulse-en', locale: 'en' };
+    const lockedDeRow = {
+      id: 'int-locked-de',
+      text: 'Original DE Mond text',
+      selected_archetype_key: 'mond',
+      locale: 'de',
+      daily_pulse_id: 'pulse-de',
+    };
+
+    let dailyPulsesGetCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input
+        : input instanceof URL ? input.toString()
+          : input?.url ?? '';
+      if (url.includes('auth/v1/user')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ id: 'user-1', email: 't@test.com', aud: 'authenticated' }),
+          text: async () => JSON.stringify({ id: 'user-1' }),
+        };
+      }
+      if (url.includes('/daily_pulses')) {
+        dailyPulsesGetCount += 1;
+        const data = dailyPulsesGetCount === 1 ? [enPulse] : [dePulse, enPulse];
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => data,
+          text: async () => JSON.stringify(data),
+        };
+      }
+      if (url.includes('/daily_interpretations')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => [lockedDeRow],
+          text: async () => JSON.stringify([lockedDeRow]),
+        };
+      }
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({}),
+        text: async () => '{}',
+      };
+    });
+
+    const geminiClass = makeGeminiTextMock('SHOULD NOT BE CALLED');
+    const app = await loadApp(geminiClass);
+
+    const res = await request(app)
+      .post('/api/daily-interpretation')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send({
+        daily_pulse_id: 'pulse-en',
+        selected_archetype_key: 'mond',  // same archetype
+        locale: 'en',                    // different locale
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error?.code).toBe('ALREADY_DECIDED');
+    expect(res.body?.error?.locked_archetype_key).toBe('mond');
+    expect(res.body?.error?.text).toBe('Original DE Mond text');
+  });
 });

--- a/server/__tests__/daily-interpretation.test.mjs
+++ b/server/__tests__/daily-interpretation.test.mjs
@@ -516,4 +516,108 @@ describe('POST /api/daily-interpretation — no-placeholders contract', () => {
     // Regenerate clause: if output ≈ slot_2 or slot_3, regenerate.
     expect(captured.prompt).toMatch(/regener/i);
   });
+
+  it('DIN-RACE-001: 23505 from concurrent insert → 409 ALREADY_DECIDED with re-fetched winner', async () => {
+    // Audit follow-up I-2: between our pre-check (which sees null) and
+    // our INSERT, a concurrent request can sneak in and create the row.
+    // The unique constraint daily_interpretations_one_per_pulse rejects
+    // us with Postgres 23505. We must NOT return generic 500 — instead
+    // re-fetch the winning row and return 409 with the same envelope
+    // shape as the pre-check path.
+
+    let interpretationGetCount = 0;
+    const winnerRow = {
+      id: 'int-winner',
+      text: 'Concurrent winner picked sonne',
+      selected_archetype_key: 'sonne',
+      locale: 'de',
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input
+        : input instanceof URL ? input.toString()
+          : input?.url ?? '';
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.includes('auth/v1/user')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ id: 'user-1', email: 't@test.com', aud: 'authenticated' }),
+          text: async () => JSON.stringify({ id: 'user-1' }),
+        };
+      }
+      if (url.includes('/daily_pulses')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => [PULSE_ROW],
+          text: async () => JSON.stringify([PULSE_ROW]),
+        };
+      }
+      if (url.includes('/astro_profiles')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => PROFILE_FIXTURE,
+          text: async () => JSON.stringify(PROFILE_FIXTURE),
+        };
+      }
+      if (url.includes('/daily_interpretations')) {
+        const headers = init?.headers || {};
+        const acceptRaw = headers instanceof Headers ? headers.get('accept') : (headers['Accept'] ?? headers.accept ?? '');
+        const wantsObject = String(acceptRaw || '').includes('vnd.pgrst.object');
+
+        if (method === 'POST') {
+          // Simulate race-loser: concurrent insert beat us. Postgres
+          // 23505 unique violation surfaces via PostgREST as 409 with
+          // code='23505' in the body.
+          return {
+            ok: false, status: 409,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => ({ code: '23505', message: 'duplicate key value violates unique constraint "daily_interpretations_one_per_pulse"' }),
+            text: async () => '{"code":"23505"}',
+          };
+        }
+        // GET: first call (pre-check) returns null, second call
+        // (re-fetch after 23505) returns the winner.
+        interpretationGetCount += 1;
+        const list = interpretationGetCount === 1 ? [] : [winnerRow];
+        const body = wantsObject ? (list[0] ?? null) : list;
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => body,
+          text: async () => JSON.stringify(body),
+        };
+      }
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({}),
+        text: async () => '{}',
+      };
+    });
+
+    const app = await loadApp(makeGeminiTextMock('Should not matter — race-loser path skips AI re-call.'));
+
+    const res = await request(app)
+      .post('/api/daily-interpretation')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send({
+        daily_pulse_id: 'pulse-uuid-1',
+        selected_archetype_key: 'mond',  // we tried mond, but sonne won the race
+        locale: 'de',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error?.code).toBe('ALREADY_DECIDED');
+    expect(res.body?.error?.locked_archetype_key).toBe('sonne');
+    expect(res.body?.error?.text).toBe('Concurrent winner picked sonne');
+    // No locked_locale field (M-2 — dropped as unused).
+    expect(res.body?.error?.locked_locale).toBeUndefined();
+    // The pre-check GET fired once + the race-recovery re-fetch GET fired once = 2 total.
+    expect(interpretationGetCount).toBe(2);
+  });
 });

--- a/src/__tests__/use-daily-pulse.test.ts
+++ b/src/__tests__/use-daily-pulse.test.ts
@@ -246,4 +246,85 @@ describe('useDailyPulse', () => {
     expect(result.current.pulse?.aphorism.slot_2).toBeNull();
     expect(result.current.pulse?.aphorism.slot_3).toBeNull();
   });
+
+  // ── 409 ALREADY_DECIDED handling (PR #335 review I-4) ──────────────────────
+  // The hook surfaces a server 409 as if it were the current selection,
+  // so the user sees their own previous choice rendered in Phase 2 with
+  // no error UI. Three regression guards:
+
+  it('DPH-LOCK-001: 409 with full envelope surfaces locked archetype as selection', async () => {
+    // Pulse loads normally
+    authedFetch.mockResolvedValueOnce(makeRes(200, VALID_PULSE));
+    // Then user picks 'sonne' but server returns 409 — they already picked 'mond' earlier.
+    authedFetch.mockResolvedValueOnce(
+      makeRes(409, {
+        error: {
+          code: 'ALREADY_DECIDED',
+          locked_archetype_key: 'mond',
+          text: 'Locked Mond text from earlier today',
+        },
+      }),
+    );
+    const useDailyPulse = await loadHook();
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.selectCouncilFigure('sonne');
+    });
+    await waitFor(() => expect(result.current.loadingInterpretation).toBe(false));
+
+    // Hook surfaces the LOCKED archetype, not what the user clicked.
+    expect(result.current.selectedFigure).toBe('mond');
+    expect(result.current.interpretation?.text).toBe('Locked Mond text from earlier today');
+    // No error envelope — locked decision is the canonical Phase 2 view.
+    expect(result.current.interpretationError).toBeNull();
+  });
+
+  it('DPH-LOCK-002: 409 with malformed envelope (missing locked_archetype_key) falls back to error UI', async () => {
+    // Defense-in-depth: if the server ever sends a malformed 409 (e.g.,
+    // bug in error formatting), the hook must not silently set
+    // selectedFigure to undefined. It falls through to the generic
+    // error mapping so the user sees a retry button rather than a
+    // blank Phase 2.
+    authedFetch.mockResolvedValueOnce(makeRes(200, VALID_PULSE));
+    authedFetch.mockResolvedValueOnce(
+      makeRes(409, { error: { code: 'ALREADY_DECIDED' /* missing locked_* + text */ } }),
+    );
+    const useDailyPulse = await loadHook();
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.selectCouncilFigure('sonne');
+    });
+    await waitFor(() => expect(result.current.loadingInterpretation).toBe(false));
+
+    // Did NOT silently lock — user keeps the archetype they clicked
+    // (or the existing selection state) but gets a proper error code.
+    expect(result.current.interpretation).toBeNull();
+    // Status 409 maps to the generic 'unknown' bucket via mapStatusToError.
+    expect(result.current.interpretationError?.code).toBe('unknown');
+  });
+
+  it('DPH-LOCK-003: 409 with locked_archetype_key but missing text falls back to error UI', async () => {
+    // Defensive: text is the rendered content. Without it, surfacing
+    // the locked archetype with no text would render Phase 2 with an
+    // empty body. Better to force a retry.
+    authedFetch.mockResolvedValueOnce(makeRes(200, VALID_PULSE));
+    authedFetch.mockResolvedValueOnce(
+      makeRes(409, { error: { code: 'ALREADY_DECIDED', locked_archetype_key: 'mond' /* missing text */ } }),
+    );
+    const useDailyPulse = await loadHook();
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.selectCouncilFigure('sonne');
+    });
+    await waitFor(() => expect(result.current.loadingInterpretation).toBe(false));
+
+    expect(result.current.interpretation).toBeNull();
+    expect(result.current.interpretationError?.code).toBe('unknown');
+  });
 });

--- a/src/components/dashboard/TagespulsCard.tsx
+++ b/src/components/dashboard/TagespulsCard.tsx
@@ -342,9 +342,18 @@ export function TagespulsCard({ onCompleteProfile }: TagespulsCardProps) {
               signOrElement={c.signOrElement}
               label={t(COUNCIL_KEY_TO_I18N[c.key] ?? 'tagespuls.council.sonne')}
               onClick={() => selectCouncilFigure(c.key)}
-              // After the user picks (selectedFigure becomes non-null) or
-              // while a request is in-flight, all 6 buttons lock —
-              // spec C-3: "Es geht nur einmal am Tag".
+              // Lock conditions per spec C-3: "Es geht nur einmal am Tag".
+              //
+              // `loadingInterpretation`: in-flight request — prevent
+              //   double-click race (user clicks figure A, then B before
+              //   A returns; the second click would queue a 2nd LLM call).
+              //
+              // `selectedFigure !== null`: belt-and-braces. Phase 1 only
+              //   renders when selectedFigure === null (line 215 routes
+              //   to Phase 2 once it's set), so this branch is normally
+              //   unreachable from a re-render. Kept as defensive guard
+              //   for hypothetical future layouts where Phase 1 + Phase 2
+              //   coexist (e.g., embedded preview).
               disabled={selectedFigure !== null || loadingInterpretation}
             />
           ))}


### PR DESCRIPTION
## Summary

Closes 7 of 9 findings from the 2026-05-09 PR #335 code review. M-2 (drop locked_locale) folded into Group A. M-4 (migration drop fallback) explicitly deferred — migration already deployed, comment-only changes have no value on shipped artifact.

| Commit | Findings | Hash | Suite delta |
|---|---|---|---|
| 1. `fix(tagespuls): reorder existing-row check + 23505 race-loser → 409` | I-1, I-2, M-2 | `6e0d69b` | 11 → 12 |
| 2. `fix(tagespuls): scope decision lock by (user_id, date) — close locale loophole` | I-3 | `39387d1` | 12 → 14 |
| 3. `test(use-daily-pulse): cover 409 ALREADY_DECIDED handling` | I-4 | `8c844a1` | 8 → 11 |
| 4. `docs(tagespuls): clarify hygiene comments` | M-1, M-3, M-5 | `6e8bf84` | unchanged |

## Highlights

### I-1 — performance: existing-row check first
Pre-fix: every interpretation request reloaded `astro_profiles` (~5ms + council build), even for cache hits. Post-fix: page-reloads after first pick short-circuit on the lock. Saves 1 Supabase roundtrip per cache-hit.

### I-2 — race-loser → 409 with same envelope
Pre-fix: concurrent inserts caused 23505 unique-violation → caught as generic 500. Race-losers got different UX than pre-check-hits. Post-fix: 23505 detected, winner re-fetched, returned as 409 ALREADY_DECIDED. Same envelope shape.

### I-3 — locale-switching loophole closed
Daily_pulses are keyed `(user_id, date, locale)` so locale-switching gave each user a fresh `daily_pulse_id` and a fresh chance to pick. Pre-fix: existing-row check scoped per-pulse. Post-fix: scoped per `(user_id, date)` via two-query path (collect all pulse_ids for date → first interpretation across that set). Matches "first decision wins" semantic from the migration cleanup.

### I-4 — 409 envelope handling tested
Three new hook tests: full envelope (locked archetype surfaced), malformed envelope missing `locked_archetype_key` (graceful fallback to retry UI), missing text (same fallback).

### M-1, M-3, M-5 — clarifying comments
Disabled-prop dual-condition rationale (real vs belt-and-braces); 422 PROFILE_REQUIRED race-window timing made explicit; console.error log redaction stance documented with upgrade path to `redactLog`.

## Test plan

- [ ] `npx vitest run server/__tests__/daily-interpretation.test.mjs` → **14/14** (was 11/11)
- [ ] `npx vitest run src/__tests__/use-daily-pulse.test.ts` → **11/11** (was 8/8)
- [ ] `npx vitest run src/__tests__/tagespuls-card.test.tsx` → **12/12** (unchanged)
- [ ] Full suite: 2354/2357 — 3 pre-existing failures (vibes-perf flake, EDF-NCP-003, api-daily-pulse idempotent) verified unrelated
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run build` — OK in 12.62s
- [ ] Manual smoke after Railway redeploy:
  - Pick on locale=de, switch to en, try to pick → 409 with locked DE info renders as Phase 2 (no Phase 1 retry)
  - Page reload after first pick → cached decision served fast (no profile reload roundtrip)
  - DB constraint trigger via concurrent insert (theoretical) → 409 not 500

## Stacked PR

This PR depends on [PR #335 — Tagespuls Phase 2 strict rules](https://github.com/DYAI2025/Astro-Noctum/pull/335). Merge order: #335 → this PR. After #335 lands, GitHub will offer to retarget this PR's base to `main` automatically.

## Out of scope (deliberate)

- M-2 (drop locked_locale field) — folded into Group A's commit since it shares the same server.mjs hunks
- M-4 (migration drop fallback comments) — migration `20260510_daily_interpretation_one_per_pulse.sql` already deployed 2026-05-09; comment-only changes have no value on shipped artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)