### PR TITLE
fix: render 3D signature trails as great‑circle arcs (antipodal handling)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -310,7 +310,6 @@ app.use(helmet({
       frameSrc: ["'self'", "https://elevenlabs.io", "https://*.elevenlabs.io", "https://checkout.stripe.com", "https://pagead2.googlesyndication.com", "https://googleads.g.doubleclick.net", "https://fundingchoicesmessages.google.com"],
       mediaSrc: ["'self'", "blob:", "https://elevenlabs.io", "https://*.elevenlabs.io"],
       workerSrc: ["'self'", "blob:", "https://elevenlabs.io", "https://*.elevenlabs.io", "https://unpkg.com"],
-      workletSrc: ["'self'", "blob:", "data:", "https://unpkg.com", "https://cdn.jsdelivr.net", "https://elevenlabs.io", "https://*.elevenlabs.io"],
       objectSrc: ["'none'"],
       baseUri: ["'self'"],
     },

--- a/src/components/signatur-3d/SignatureSphere3D.tsx
+++ b/src/components/signatur-3d/SignatureSphere3D.tsx
@@ -501,7 +501,7 @@ function AnimatedScene({
  *
  * Trail tubes:
  * - Drawn only for the 6 antipodal pole pairs whose assigned planet weight
- *   >= 0.35 (weights below render no trail, reducing triangle count).
+ *   >= 0.15 (weights below render no trail, reducing triangle count).
  *
  * Data contract:
  * - `weights` keys are the 10 Cousto planet names; missing keys default to 0.

--- a/src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx
+++ b/src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx
@@ -152,18 +152,18 @@ describe('SignatureSphere3D', () => {
   // ── H4 additions ─────────────────────────────────────────────────────────
 
   it('renders 12 glyphs (one per pole) even when all weights are sub-threshold', () => {
-    // All weights below TRAIL_THRESHOLD (0.35): glyphs still render (12), trails = 0.
+    // All weights below TRAIL_THRESHOLD (0.15): glyphs still render (12), trails = 0.
     const LOW: Readonly<Partial<Record<PlanetName, number>>> = {
-      Sun: 0.2,
-      Moon: 0.2,
-      Mercury: 0.2,
-      Venus: 0.2,
-      Mars: 0.2,
-      Jupiter: 0.2,
-      Saturn: 0.2,
-      Uranus: 0.2,
-      Neptune: 0.2,
-      Pluto: 0.2,
+      Sun: 0.1,
+      Moon: 0.1,
+      Mercury: 0.1,
+      Venus: 0.1,
+      Mars: 0.1,
+      Jupiter: 0.1,
+      Saturn: 0.1,
+      Uranus: 0.1,
+      Neptune: 0.1,
+      Pluto: 0.1,
     };
     const { queryAllByTestId } = render(<SignatureSphere3D weights={LOW} />);
     const glyphs = queryAllByTestId('drei-text-mock');

--- a/src/lib/signatur-3d/__tests__/sphere-chladni.test.ts
+++ b/src/lib/signatur-3d/__tests__/sphere-chladni.test.ts
@@ -168,5 +168,20 @@ describe('sphere-chladni', () => {
         expect(Math.abs(len - radius)).toBeLessThan(1e-9);
       }
     });
+
+    it('keeps antipodal pole-pair trails on a real great-circle arc instead of collapsing into one axis', () => {
+      const [from, to] = getPolePairs(1)[0];
+      const path = buildTrailPath(from, to, 1, 0, 3, 48, 0);
+
+      // Old behavior normalized a lerp between exact opposites, producing only
+      // +/- endpoint directions (and one origin fallback). A real branch must
+      // leave that axis by the midpoint and produce many distinct directions.
+      const midpoint = path[24];
+      expect(Math.abs(midpoint.x)).toBeLessThan(1e-9);
+      expect(Math.hypot(midpoint.y, midpoint.z)).toBeCloseTo(1, 12);
+
+      const distinctDirections = new Set(path.map((p) => pointKey(p)));
+      expect(distinctDirections.size).toBeGreaterThan(24);
+    });
   });
 });

--- a/src/lib/signatur-3d/sphere-chladni.ts
+++ b/src/lib/signatur-3d/sphere-chladni.ts
@@ -282,9 +282,11 @@ export function getPolePairs(radius: number): readonly [PolePoint, PolePoint][] 
  * poles, with a radial cymatic ripple superimposed. Used by H4 to build
  * tube-geometry trails on the sphere.
  *
- * The path linearly interpolates between `from` and `to`, re-projects each
- * sample onto the sphere surface (radius), then adds a radial ripple
- * `ripple · sin(t · π · frequency + time · 1e-3 · frequency/2)`.
+ * The path uses spherical interpolation between `from` and `to`, re-projects
+ * each sample onto the sphere surface (radius), then adds a radial ripple
+ * `ripple · sin(t · π · frequency + time · 1e-3 · frequency/2)`. Exact
+ * antipodal pairs get a deterministic perpendicular tangent so the path
+ * remains a visible great-circle branch instead of collapsing through origin.
  *
  * @param from      start pole
  * @param to        end pole
@@ -295,6 +297,73 @@ export function getPolePairs(radius: number): readonly [PolePoint, PolePoint][] 
  * @param time      monotonic ms (for animated ripple phase)
  * @returns         `steps + 1` PolePoints
  */
+function normalizePoint(p: PolePoint): PolePoint {
+  const len = Math.sqrt(p.x * p.x + p.y * p.y + p.z * p.z) || 1;
+  return { x: p.x / len, y: p.y / len, z: p.z / len };
+}
+
+function dotPoint(a: PolePoint, b: PolePoint): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function crossPoint(a: PolePoint, b: PolePoint): PolePoint {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+/**
+ * Deterministic tangent for antipodal pole pairs. A naive lerp between
+ * exact opposites collapses through the origin; this tangent selects a stable
+ * great-circle plane so every pole pair becomes a visible surface arc.
+ */
+function perpendicularUnitVector(dir: PolePoint): PolePoint {
+  const candidates: readonly PolePoint[] = [
+    { x: 1, y: 0, z: 0 },
+    { x: 0, y: 1, z: 0 },
+    { x: 0, y: 0, z: 1 },
+  ];
+  const leastAligned = candidates.reduce((best, candidate) => (
+    Math.abs(dotPoint(dir, candidate)) < Math.abs(dotPoint(dir, best)) ? candidate : best
+  ));
+
+  return normalizePoint(crossPoint(leastAligned, dir));
+}
+
+function interpolateGreatCircle(fromDir: PolePoint, toDir: PolePoint, t: number): PolePoint {
+  const dot = Math.max(-1, Math.min(1, dotPoint(fromDir, toDir)));
+
+  if (dot < -0.999999) {
+    const tangent = perpendicularUnitVector(fromDir);
+    const angle = Math.PI * t;
+    return {
+      x: Math.cos(angle) * fromDir.x + Math.sin(angle) * tangent.x,
+      y: Math.cos(angle) * fromDir.y + Math.sin(angle) * tangent.y,
+      z: Math.cos(angle) * fromDir.z + Math.sin(angle) * tangent.z,
+    };
+  }
+
+  if (dot > 0.999999) {
+    return normalizePoint({
+      x: fromDir.x + (toDir.x - fromDir.x) * t,
+      y: fromDir.y + (toDir.y - fromDir.y) * t,
+      z: fromDir.z + (toDir.z - fromDir.z) * t,
+    });
+  }
+
+  const angle = Math.acos(dot);
+  const sinAngle = Math.sin(angle);
+  const a = Math.sin((1 - t) * angle) / sinAngle;
+  const b = Math.sin(t * angle) / sinAngle;
+  return {
+    x: a * fromDir.x + b * toDir.x,
+    y: a * fromDir.y + b * toDir.y,
+    z: a * fromDir.z + b * toDir.z,
+  };
+}
+
 export function buildTrailPath(
   from: PolePoint,
   to: PolePoint,
@@ -306,41 +375,20 @@ export function buildTrailPath(
 ): readonly PolePoint[] {
   const n = steps ?? 48;
   const out: PolePoint[] = [];
+  const fromDir = normalizePoint(from);
+  const toDir = normalizePoint(to);
 
   for (let s = 0; s <= n; s++) {
     const t = s / n;
-    // lerp
-    const lx = from.x + (to.x - from.x) * t;
-    const ly = from.y + (to.y - from.y) * t;
-    const lz = from.z + (to.z - from.z) * t;
-
-    // normalize & scale to sphere surface (with tiny epsilon to stay stable
-    // when endpoints happen to be antipodal and t is exactly 0.5 — the lerp
-    // then hits the origin. We fall back to the `from` direction in that
-    // degenerate case.)
-    const len = Math.sqrt(lx * lx + ly * ly + lz * lz);
-    let nx: number;
-    let ny: number;
-    let nz: number;
-    if (len < 1e-9) {
-      const fromLen = Math.sqrt(from.x * from.x + from.y * from.y + from.z * from.z) || 1;
-      nx = from.x / fromLen;
-      ny = from.y / fromLen;
-      nz = from.z / fromLen;
-    } else {
-      nx = lx / len;
-      ny = ly / len;
-      nz = lz / len;
-    }
-
+    const dir = interpolateGreatCircle(fromDir, toDir, t);
     const rippleOffset =
       ripple * Math.sin(t * Math.PI * frequency + time * 0.001 * (frequency / 2));
     const effectiveRadius = radius + rippleOffset;
 
     out.push({
-      x: nx * effectiveRadius,
-      y: ny * effectiveRadius,
-      z: nz * effectiveRadius,
+      x: dir.x * effectiveRadius,
+      y: dir.y * effectiveRadius,
+      z: dir.z * effectiveRadius,
     });
   }
 


### PR DESCRIPTION
### Motivation
- Die 3D-Signatur-Trails erschienen oft kaum sichtbar, weil Pfad-Samples zwischen antipodalen Polpaaren durch lineare Lerp+Normalisierung degenerierten und entlang einer Achse kollabierten.
- Parallel meldete die Konsole wiederholt die CSP-Warnung über `worklet-src` obwohl keine Worklets genutzt werden, was Rauschen erzeugte und das Debugging störte.

### Description
- Ersetze die lineare Interpolation in `buildTrailPath` durch sphärische Interpolation (great‑circle) und füge explizite Behandlung für exakte Antipoden mit einem deterministischen Tangentenvektor hinzu, damit Trails als sichtbare Bögen laufen (`src/lib/signatur-3d/sphere-chladni.ts`).
- Ergänze helper-Funktionen `normalizePoint`, `interpolateGreatCircle`, `perpendicularUnitVector`, `dotPoint`, `crossPoint` und passe `buildTrailPath` an, um normale, kollineare und antipodale Fälle korrekt zu behandeln (`src/lib/signatur-3d/sphere-chladni.ts`).
- Füge einen Regressionstest hinzu, der explizit ein antipodales Polpaar aus `getPolePairs()` prüft und sicherstellt, dass die Pfad-Mittelstellung die Achse verlässt und viele unterschiedliche Richtungen erzeugt (`src/lib/signatur-3d/__tests__/sphere-chladni.test.ts`).
- Aktualisiere begleitende Tests/Dokumentation, damit die tatsächliche `TRAIL_THRESHOLD = 0.15` konsistent reflektiert wird (`src/components/signatur-3d/SignatureSphere3D.tsx` and its tests).
- Entferne die unbenutzte/inkompatible CSP-Direktive `workletSrc` aus `server.mjs`, um die wiederkehrenden `Unrecognized Content-Security-Policy directive 'worklet-src'`-Warnungen zu unterbinden.

### Testing
- Zieltests für die 3D-Änderung ausgeführt: `src/lib/signatur-3d/__tests__/sphere-chladni.test.ts` und `src/components/signatur-3d/__tests__/SignatureSphere3D.test.tsx` — alle relevanten Tests bestanden (2 test files, 27 tests passed).
- Komplettes Testlauf (`npm test`) in dieser Umgebung schlägt fehl; Fehler sind extern/umgebungsbedingt: fehlende Supabase-Env-Variablen, nicht laufende lokale Dienste (`127.0.0.1:3000/3001`) und ein vorhandenes `express-rate-limit` IPv6 key-generator Validierungsproblem; diese Probleme sind unabhängig von den 3D-Änderungen und betreffen globale Testinfrastruktur.
- Lint (`tsc --noEmit`) bestanden.
- Produktions-Build (`npm run build`) erfolgreich erstellt (Vite build completed; chunk-size warnings are informational).

Automatisierte Testergebnisse im Kurzüberblick:
- Focused 3D tests: ✅ passed
- `npm run lint`: ✅ passed
- `npm run build`: ✅ passed
- Full `npm test`: ⚠️ failed due to environment (Supabase env / local ports / express-rate-limit IPv6), not due to the changes in this PR

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a000e8200f883229ede9e094c36a494)