### PR TITLE
Enforce date-scoped Tagespuls lock at write time (DB trigger + migration + server/test updates)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -3400,16 +3400,23 @@ app.post('/api/daily-interpretation', requireUserAuth, dailyInterpretationLimite
       // Audit follow-up I-2: race-condition victim. Between our
       // pre-check and this insert, a concurrent request snuck in and
       // created the row. The unique constraint
-      // daily_interpretations_one_per_pulse rejects us with Postgres
+      // daily_interpretations_one_per_user_date rejects us with Postgres
       // 23505. Re-fetch the winning row and return 409 with the same
       // envelope shape as the pre-check path — race-losers get the
       // same UX as pre-check-hits, not a generic 500.
       if (insErr?.code === '23505') {
-        const { data: winner } = await supabaseServer
+        // The DB backstop is date-scoped (user_id, pulse_date), not just
+        // daily_pulse_id. A locale-switch race can lose against a row on
+        // a sibling pulse for the same Kalendertag, so recover via the
+        // same date-wide lookup as the pre-check instead of filtering to
+        // the requested pulse_id.
+        const { data: winnerList } = await supabaseServer
           .from('daily_interpretations')
-          .select('id, text, selected_archetype_key')
-          .eq('daily_pulse_id', dailyPulseId)
-          .maybeSingle();
+          .select('id, text, selected_archetype_key, locale, daily_pulse_id')
+          .in('daily_pulse_id', pulseIdsForDate)
+          .order('created_at', { ascending: true })
+          .limit(1);
+        const winner = winnerList?.[0] ?? null;
         if (winner) {
           return res.status(409).json({
             error: {

--- a/server/__tests__/daily-interpretation.test.mjs
+++ b/server/__tests__/daily-interpretation.test.mjs
@@ -520,7 +520,7 @@ describe('POST /api/daily-interpretation — no-placeholders contract', () => {
   it('DIN-RACE-001: 23505 from concurrent insert → 409 ALREADY_DECIDED with re-fetched winner', async () => {
     // Audit follow-up I-2: between our pre-check (which sees null) and
     // our INSERT, a concurrent request can sneak in and create the row.
-    // The unique constraint daily_interpretations_one_per_pulse rejects
+    // The unique constraint daily_interpretations_one_per_user_date rejects
     // us with Postgres 23505. We must NOT return generic 500 — instead
     // re-fetch the winning row and return 409 with the same envelope
     // shape as the pre-check path.
@@ -575,7 +575,7 @@ describe('POST /api/daily-interpretation — no-placeholders contract', () => {
           return {
             ok: false, status: 409,
             headers: new Headers({ 'content-type': 'application/json' }),
-            json: async () => ({ code: '23505', message: 'duplicate key value violates unique constraint "daily_interpretations_one_per_pulse"' }),
+            json: async () => ({ code: '23505', message: 'duplicate key value violates unique constraint "daily_interpretations_one_per_user_date"' }),
             text: async () => '{"code":"23505"}',
           };
         }
@@ -618,6 +618,102 @@ describe('POST /api/daily-interpretation — no-placeholders contract', () => {
     // No locked_locale field (M-2 — dropped as unused).
     expect(res.body?.error?.locked_locale).toBeUndefined();
     // The pre-check GET fired once + the race-recovery re-fetch GET fired once = 2 total.
+    expect(interpretationGetCount).toBe(2);
+  });
+
+  it('DIN-RACE-002: 23505 from cross-locale concurrent insert → 409 with date-scoped winner', async () => {
+    // Regression for PR #336 review: the pre-check is not sufficient on
+    // its own. Two locale-switch requests can both see no interpretation
+    // for the date and then race to insert different daily_pulse_id rows.
+    // The DB must reject the loser with the date-scoped unique constraint,
+    // and the server must re-fetch the winner across all pulse ids for the
+    // date rather than only the requested EN pulse.
+    const dePulse = { ...PULSE_ROW, id: 'pulse-de', locale: 'de' };
+    const enPulse = { ...PULSE_ROW, id: 'pulse-en', locale: 'en' };
+    const winnerRow = {
+      id: 'int-winner-de',
+      text: 'Concurrent DE winner picked mond',
+      selected_archetype_key: 'mond',
+      locale: 'de',
+      daily_pulse_id: 'pulse-de',
+    };
+
+    let dailyPulsesGetCount = 0;
+    let interpretationGetCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input
+        : input instanceof URL ? input.toString()
+          : input?.url ?? '';
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.includes('auth/v1/user')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ id: 'user-1', email: 't@test.com', aud: 'authenticated' }),
+          text: async () => JSON.stringify({ id: 'user-1' }),
+        };
+      }
+      if (url.includes('/daily_pulses')) {
+        dailyPulsesGetCount += 1;
+        const data = dailyPulsesGetCount === 1 ? [enPulse] : [dePulse, enPulse];
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => data,
+          text: async () => JSON.stringify(data),
+        };
+      }
+      if (url.includes('/astro_profiles')) {
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => PROFILE_FIXTURE,
+          text: async () => JSON.stringify(PROFILE_FIXTURE),
+        };
+      }
+      if (url.includes('/daily_interpretations')) {
+        if (method === 'POST') {
+          return {
+            ok: false, status: 409,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => ({ code: '23505', message: 'duplicate key value violates unique constraint "daily_interpretations_one_per_user_date"' }),
+            text: async () => '{"code":"23505"}',
+          };
+        }
+        interpretationGetCount += 1;
+        const list = interpretationGetCount === 1 ? [] : [winnerRow];
+        return {
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => list,
+          text: async () => JSON.stringify(list),
+        };
+      }
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({}),
+        text: async () => '{}',
+      };
+    });
+
+    const app = await loadApp(makeGeminiTextMock('Generated EN text that loses the cross-locale race.'));
+
+    const res = await request(app)
+      .post('/api/daily-interpretation')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send({
+        daily_pulse_id: 'pulse-en',
+        selected_archetype_key: 'sonne',
+        locale: 'en',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error?.code).toBe('ALREADY_DECIDED');
+    expect(res.body?.error?.locked_archetype_key).toBe('mond');
+    expect(res.body?.error?.text).toBe('Concurrent DE winner picked mond');
     expect(interpretationGetCount).toBe(2);
   });
 

--- a/supabase-migrations/20260510_daily_interpretation_one_per_user_date.sql
+++ b/supabase-migrations/20260510_daily_interpretation_one_per_user_date.sql
@@ -1,0 +1,80 @@
+-- Tagespuls: enforce one interpretation decision per user/Kalendertag.
+--
+-- PR #336 review follow-up: the application pre-check scans all pulse ids
+-- for a date, but two concurrent locale-switch requests can both observe no
+-- row and then insert against different daily_pulse_id values. A UNIQUE
+-- (daily_pulse_id) backstop does not catch that race because daily_pulses are
+-- keyed by (user_id, date, locale). This migration adds write-time scope
+-- columns populated from daily_pulses and an atomic UNIQUE (user_id, pulse_date)
+-- constraint so the database enforces "first decision wins per Kalendertag".
+
+ALTER TABLE daily_interpretations
+  ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS pulse_date DATE;
+
+CREATE OR REPLACE FUNCTION set_daily_interpretation_scope()
+RETURNS TRIGGER AS $$
+BEGIN
+  SELECT dp.user_id, dp.date
+    INTO NEW.user_id, NEW.pulse_date
+  FROM daily_pulses dp
+  WHERE dp.id = NEW.daily_pulse_id;
+
+  IF NEW.user_id IS NULL OR NEW.pulse_date IS NULL THEN
+    RAISE EXCEPTION 'daily_pulse_id % does not exist', NEW.daily_pulse_id
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_daily_interpretations_scope ON daily_interpretations;
+CREATE TRIGGER trg_daily_interpretations_scope
+  BEFORE INSERT OR UPDATE OF daily_pulse_id ON daily_interpretations
+  FOR EACH ROW
+  EXECUTE FUNCTION set_daily_interpretation_scope();
+
+UPDATE daily_interpretations di
+SET user_id = dp.user_id,
+    pulse_date = dp.date
+FROM daily_pulses dp
+WHERE dp.id = di.daily_pulse_id
+  AND (di.user_id IS NULL OR di.pulse_date IS NULL);
+
+-- If the locale loophole already produced multiple rows for one user/date,
+-- keep the earliest decision and delete later siblings before adding the
+-- one-per-day constraint. This matches the server's "first decision wins"
+-- ordering and prevents the migration from failing on historical data.
+WITH ranked AS (
+  SELECT
+    di.id,
+    row_number() OVER (
+      PARTITION BY di.user_id, di.pulse_date
+      ORDER BY di.created_at ASC, di.id ASC
+    ) AS rn
+  FROM daily_interpretations di
+)
+DELETE FROM daily_interpretations di
+USING ranked r
+WHERE di.id = r.id
+  AND r.rn > 1;
+
+ALTER TABLE daily_interpretations
+  ALTER COLUMN user_id SET NOT NULL,
+  ALTER COLUMN pulse_date SET NOT NULL;
+
+-- Keep the per-pulse uniqueness as a narrower invariant, but add the real
+-- date-scoped backstop needed for locale-switch concurrency.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'daily_interpretations'::regclass
+      AND conname = 'daily_interpretations_one_per_user_date'
+  ) THEN
+    ALTER TABLE daily_interpretations
+      ADD CONSTRAINT daily_interpretations_one_per_user_date UNIQUE (user_id, pulse_date);
+  END IF;
+END $$;

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -321,17 +321,42 @@ ALTER TABLE daily_pulses ENABLE ROW LEVEL SECURITY;
 CREATE TABLE IF NOT EXISTS daily_interpretations (
   id                       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   daily_pulse_id           UUID        NOT NULL REFERENCES daily_pulses(id) ON DELETE CASCADE,
+  user_id                  UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  pulse_date               DATE        NOT NULL,
   selected_archetype_key   TEXT        NOT NULL CHECK (selected_archetype_key IN ('sonne','mond','aszendent','day_master','jahrestier','wuxing_dom')),
   locale                   TEXT        NOT NULL DEFAULT 'de',
   text                     TEXT        NOT NULL,
   created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
   -- Per 2026-05-09 audit C-3 ("Es geht nur einmal am Tag"): at most one
-  -- interpretation row per daily_pulse_id. Server-side pre-check returns
-  -- 409 ALREADY_DECIDED before insertion; this constraint is the DB-layer
-  -- backstop for concurrent inserts. See migration
-  -- 20260510_daily_interpretation_one_per_pulse.sql.
-  CONSTRAINT daily_interpretations_one_per_pulse UNIQUE (daily_pulse_id)
+  -- interpretation row per user/Kalendertag. A trigger copies user_id and
+  -- pulse_date from daily_pulses at write time, so concurrent locale-switch
+  -- inserts collide atomically on this constraint instead of slipping past
+  -- an application pre-check.
+  CONSTRAINT daily_interpretations_one_per_pulse UNIQUE (daily_pulse_id),
+  CONSTRAINT daily_interpretations_one_per_user_date UNIQUE (user_id, pulse_date)
 );
+
+CREATE OR REPLACE FUNCTION set_daily_interpretation_scope()
+RETURNS TRIGGER AS $$
+BEGIN
+  SELECT dp.user_id, dp.date
+    INTO NEW.user_id, NEW.pulse_date
+  FROM daily_pulses dp
+  WHERE dp.id = NEW.daily_pulse_id;
+
+  IF NEW.user_id IS NULL OR NEW.pulse_date IS NULL THEN
+    RAISE EXCEPTION 'daily_pulse_id % does not exist', NEW.daily_pulse_id
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_daily_interpretations_scope
+  BEFORE INSERT OR UPDATE OF daily_pulse_id ON daily_interpretations
+  FOR EACH ROW
+  EXECUTE FUNCTION set_daily_interpretation_scope();
 
 ALTER TABLE daily_interpretations ENABLE ROW LEVEL SECURITY;
 


### PR DESCRIPTION
### Motivation

- Close a locale-switch race where two concurrent requests for the same user/date but different `daily_pulse_id` could both insert and violate the intended “first decision wins per Kalendertag” semantic.  
- The existing `UNIQUE (daily_pulse_id)` DB backstop was insufficient for cross-locale races because `daily_pulses` are keyed `(user_id, date, locale)`.  
- Ensure race-losers return the same `409 ALREADY_DECIDED` envelope UX as pre-check hits, not a generic 500.

### Description

- Add write-time scope to `daily_interpretations` by denormalizing `user_id` and `pulse_date` columns, plus a trigger function `set_daily_interpretation_scope()` that populates them from `daily_pulses`, and enforce `UNIQUE (user_id, pulse_date)` alongside the per-pulse uniqueness in `supabase-schema.sql`.  
- Add migration `supabase-migrations/20260510_daily_interpretation_one_per_user_date.sql` that backfills the new columns, deletes later duplicate rows keeping the earliest decision (first-decision-wins), makes the new columns `NOT NULL`, and creates the date-scoped unique constraint atomically.  
- Update `server.mjs` race recovery so that on Postgres `23505` the server re-fetches the winning interpretation across all pulse IDs for the user/date (the same date-wide lookup used by the pre-check) and returns a `409 ALREADY_DECIDED` envelope with `locked_archetype_key` and `text`.  
- Add a regression integration test `DIN-RACE-002` in `server/__tests__/daily-interpretation.test.mjs` that simulates the cross-locale concurrent-insert scenario and verifies the server recovers the date-scoped winner and returns `409` as expected.

### Testing

- Ran `npx vitest run server/__tests__/daily-interpretation.test.mjs` and observed `15/15` tests passed.  
- Ran `npm run lint` (TypeScript check) and `npm run build` and both completed successfully.  
- New migration file added: `supabase-migrations/20260510_daily_interpretation_one_per_user_date.sql`, which includes backfill and deduplication logic to avoid migration-time failures on historical data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0012e8b0f083228a2d787fef1331b9)