### PR TITLE
fix(tagespuls): dedupe interpretations before adding unique constraint

### DIFF
--- a/supabase-migrations/20260510_daily_interpretation_one_per_pulse.sql
+++ b/supabase-migrations/20260510_daily_interpretation_one_per_pulse.sql
@@ -27,6 +27,24 @@ BEGIN
   END IF;
 END $$;
 
+-- Existing installs may already have multiple interpretations for one pulse
+-- because the old rule only prevented duplicate (pulse, archetype, locale)
+-- triples. Keep the earliest recorded decision for each daily_pulse_id and
+-- remove later picks before adding the stricter one-row-per-pulse constraint.
+WITH ranked_interpretations AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY daily_pulse_id
+      ORDER BY created_at ASC, id ASC
+    ) AS decision_rank
+  FROM daily_interpretations
+)
+DELETE FROM daily_interpretations AS daily_interpretation
+USING ranked_interpretations
+WHERE daily_interpretation.id = ranked_interpretations.id
+  AND ranked_interpretations.decision_rank > 1;
+
 -- Add the new constraint: at most one interpretation per daily_pulse_id.
 ALTER TABLE daily_interpretations
   ADD CONSTRAINT daily_interpretations_one_per_pulse UNIQUE (daily_pulse_id);


### PR DESCRIPTION
### Motivation
- The one-per-pulse migration (`daily_interpretations_one_per_pulse`) would abort on installs that already contain multiple `daily_interpretations` for the same `daily_pulse_id` because the old schema allowed multiple archetype picks. 
- The migration must deterministically cleanup legacy multi-pick rows before applying the stricter `UNIQUE (daily_pulse_id)` constraint so existing databases can migrate without failure.

### Description
- Modified the migration file `supabase-migrations/20260510_daily_interpretation_one_per_pulse.sql` to add a deterministic cleanup step prior to adding the new constraint. 
- The migration now computes `row_number()` partitioned by `daily_pulse_id` ordered by `created_at ASC, id ASC` and deletes any rows with `decision_rank > 1`, preserving the earliest recorded decision per pulse. 
- The final `ALTER TABLE ... ADD CONSTRAINT daily_interpretations_one_per_pulse UNIQUE (daily_pulse_id)` remains in place after the cleanup so the stricter rule can be applied safely.

### Testing
- Ran `git diff --check` which reported no whitespace/format errors and committed the change. 
- Ran `npm run lint` (`tsc --noEmit`) which completed successfully. 
- Ran the test suite with `npm test` and observed unrelated local/env failures (missing `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`, some ECONNREFUSED checks, DNS `EAI_AGAIN`, and one existing `api-daily-pulse` assertion); no migration-specific automated tests were available to exercise the SQL change and the migration behaved as expected in manual review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0012e8d1208322b6ab9efc81d9fd17)

## Summary by Sourcery

Bug Fixes:
- Remove legacy duplicate daily_interpretations per daily_pulse_id by deterministically keeping only the earliest record before adding the unique constraint.