### PR TITLE
Tagespuls bug fixes — close 2026-05-10 audit (BUG-DAILY-001..005)

### DIFF
--- a/docs/plans/2026-05-10-tagespuls-bug-daily-001-005.md
+++ b/docs/plans/2026-05-10-tagespuls-bug-daily-001-005.md
@@ -1,0 +1,1189 @@
+# Tagespuls Bug Fixes — BUG-DAILY-001 through 005
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close 5 user-reported bugs on the Tagesimpuls feature: remove user-facing internal LLM labels, consolidate 3 slots into one natural impulse text, persist the decision lock across browser back / refresh / re-render, and ensure deep interpretation extends rather than replaces the daily impulse.
+
+**Architecture:** Three TDD commits + one plan-record commit. Commit 1 collapses the 3-slot prompt + render into a single consolidated `impulse_text`. Commit 2 extends `/api/daily-pulse` with an `existing_decision` field so the hook can hydrate Phase 2 directly on mount (no Phase 1 flash, no surprise pick after browser-back). Commit 3 ensures Phase 2 keeps the daily impulse text visible above the deep interpretation.
+
+**Tech Stack:** Express (`server.mjs`), Supabase (`daily_pulses` table — column reuse, no migration), Vitest + React Testing Library, German UI strings via i18n.
+
+---
+
+## Findings being addressed
+
+| ID | Severity | Where | Spec violation |
+|---|---|---|---|
+| BUG-DAILY-001 | High | `TagespulsCard.tsx:317-333` + `translations.ts:511,1039` | "Bridge to Today" / "Action Impulse" labels visible in user UI |
+| BUG-DAILY-002 | High | `Dashboard.tsx` mount + Card content | Daily Impulse position / wrong text — must be top + consolidated |
+| BUG-DAILY-003 | High | `useDailyPulse.ts` + `Dashboard.tsx` mount | Browser back-button shows Phase 1 with active selection again |
+| BUG-DAILY-004 | High | `useDailyPulse.ts` + `TagespulsCard.tsx` | After-pick lock state is not consistent across refresh / re-render |
+| BUG-DAILY-005 | High | `TagespulsCard.tsx` Phase 2 layout | Deep interpretation replaces daily impulse text instead of extending |
+
+---
+
+## Pre-flight
+
+**Step 0.1: Confirm git state**
+
+```bash
+cd /Users/benjaminpoersch/Projects/codebase/Bazodiac-WebApp/Astro-Noctum
+git branch --show-current
+git log --oneline -3
+git status --short
+```
+
+Expected:
+- Branch: `main`
+- HEAD: `aa6258a Merge pull request #332 from DYAI2025/2026-05-09-tagespuls-doc-reconciliation`
+- Status: clean (a stashed `tagespulscard parallel work` may be present — leave alone)
+
+If working tree is dirty, **STOP** and report.
+
+**Step 0.2: Create feature branch**
+
+```bash
+git switch -c 2026-05-10-tagespuls-bug-daily-001-005
+```
+
+**Step 0.3: Capture baseline test counts**
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx 2>&1 | tail -3
+npx vitest run server/__tests__/daily-pulse.test.mjs 2>&1 | tail -3
+npx vitest run server/__tests__/daily-interpretation.test.mjs 2>&1 | tail -3
+npx vitest run src/__tests__/use-daily-pulse.test.ts 2>&1 | tail -3
+```
+
+Note the counts — they're the deltas-base for each commit's report.
+
+If any suite is not green at baseline, **STOP and report** — fixing on top of broken tests will compound errors.
+
+---
+
+## Commit 1: BUG-001 + BUG-002 — Consolidated impulse text, no labels
+
+**Goal:** The LLM produces ONE consolidated paragraph (aphorism context + bridge + action impulse, woven together) instead of two separate slots. The component renders the paragraph cleanly without "Bridge to today" / "Action impulse" headers. The text reads as natural narration, not a structured form.
+
+### Architectural decisions
+
+1. **DB column reuse**, no migration. Write the consolidated text to `daily_pulses.slot_2`. Set `slot_3 = NULL` for new rows. Legacy rows that have both slots get concatenated server-side at read time.
+2. **Wire shape change**: API response gets a new `aphorism.impulse_text: string | null` field, derived server-side. `slot_2` / `slot_3` stay in the wire for backward compat (Zod still has them); component prefers `impulse_text`.
+3. **Prompt change**: rules block requires single-text output, asks for `{ "impulse_text": "..." }` JSON instead of `{ "slot_2", "slot_3" }`.
+4. **i18n cleanup**: `tagespuls.bridge` and `tagespuls.impulse` keys removed from both DE + EN trees.
+
+### Task 1: RED — assert no labels in DOM, single paragraph render
+
+**Files:**
+- Modify: `src/__tests__/tagespuls-card.test.tsx`
+
+**Step 1.1: Read the existing harness**
+
+```bash
+grep -n "TPC-\|describe(\|mockUseDailyPulse\|validPulseFixture" src/__tests__/tagespuls-card.test.tsx | head -15
+```
+
+Note the existing fixtures — find `validPulseFixture` or similar. Check whether it has `slot_2` / `slot_3` fields, and whether it already has `impulse_text` (it shouldn't yet).
+
+**Step 1.2: Add the failing test**
+
+Append after the most recent test (likely TPC-LOCK-002 or TPC-NO-BACK-001):
+
+```tsx
+  it('TPC-NO-LABELS-001: no internal Bridge/Impulse labels appear in Phase 1', () => {
+    // BUG-DAILY-001: "Bridge to today" / "Action impulse" are internal
+    // prompt labels and must never appear in user-facing UI.
+    mockUseDailyPulse({
+      pulse: {
+        ...validPulseFixture,
+        aphorism: {
+          ...validPulseFixture.aphorism,
+          impulse_text: 'Heute trägt Mass mehr als der nächste Beweis. Schau hin, ohne sofort zu bewerten.',
+          slot_2: null,
+          slot_3: null,
+        },
+      },
+      selectedFigure: null,
+    });
+    render(<TagespulsCard />);
+
+    // Anti-label DOM walk — neither EN nor DE label may appear
+    expect(screen.queryByText(/Bridge to today/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Brücke ins Heute/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Action impulse/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Handlungsimpuls/i)).not.toBeInTheDocument();
+
+    // The consolidated impulse text IS rendered
+    expect(screen.getByText(/Heute trägt Mass/i)).toBeInTheDocument();
+
+    // Old testids gone (we expect to delete tagespuls-bridge / tagespuls-impulse
+    // and replace with a single tagespuls-impulse-text)
+    expect(screen.queryByTestId('tagespuls-bridge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tagespuls-impulse')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tagespuls-impulse-text')).toBeInTheDocument();
+  });
+
+  it('TPC-NO-LABELS-002: legacy 2-slot fixture (slot_2 + slot_3) still renders without labels — server consolidates', () => {
+    // Backward compat: cached pulse rows from before this fix have both
+    // slot_2 and slot_3 populated. The server normalizes them into
+    // impulse_text. The component renders impulse_text only, never the
+    // raw slots.
+    mockUseDailyPulse({
+      pulse: {
+        ...validPulseFixture,
+        aphorism: {
+          ...validPulseFixture.aphorism,
+          impulse_text: 'Legacy bridge text. Legacy action impulse text.',
+          // Legacy slots stay populated for back-compat — must NOT render
+          slot_2: 'Legacy bridge text.',
+          slot_3: 'Legacy action impulse text.',
+        },
+      },
+      selectedFigure: null,
+    });
+    render(<TagespulsCard />);
+
+    expect(screen.queryByText(/Bridge to today|Brücke ins Heute|Action impulse|Handlungsimpuls/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Legacy bridge text\. Legacy action impulse text\./)).toBeInTheDocument();
+
+    // The raw slot_2 / slot_3 strings should NOT appear as separate
+    // sections — only impulse_text (which the server constructed by
+    // joining legacy slots).
+    const bridgeSpans = screen.queryAllByTestId('tagespuls-bridge');
+    expect(bridgeSpans).toHaveLength(0);
+  });
+```
+
+**Adapt** the `validPulseFixture` reference / `mockUseDailyPulse` call to whatever the file already uses. If `validPulseFixture` doesn't currently have `impulse_text`, the test will TS-fail on the spread — that's expected (RED).
+
+**Step 1.3: Run the test to verify it fails (RED)**
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx -t "TPC-NO-LABELS" 2>&1 | tail -15
+```
+
+Expected: FAIL — either:
+- TS error: `impulse_text` doesn't exist on aphorism
+- Runtime: `Found a node matching: 'Bridge to today'` or `Brücke ins Heute`
+- `data-testid="tagespuls-impulse-text"` not found
+
+**STOP and report** if it passes — somebody already shipped this.
+
+### Task 2: GREEN — schema, server, component, i18n
+
+**Files (4 files modified):**
+- `src/lib/schemas/daily-pulse.ts` (add `impulse_text` to wire)
+- `server.mjs` (consolidate prompt + emit impulse_text + back-compat for legacy rows)
+- `src/components/dashboard/TagespulsCard.tsx` (render single paragraph)
+- `src/i18n/translations.ts` (delete bridge/impulse labels)
+
+**Step 2.1: Schema — add `impulse_text` to wire**
+
+Use Edit:
+- file_path: `/Users/benjaminpoersch/Projects/codebase/Bazodiac-WebApp/Astro-Noctum/src/lib/schemas/daily-pulse.ts`
+- old_string:
+```ts
+export const PulseWireAphorismSchema = z.object({
+  id: z.string().nullable(),
+  author: z.string().nullable(),
+  attribution_status: AttributionStatusSchema.nullable(),
+  slot_1: z.string(),
+  slot_2: z.string().nullable(),
+  slot_3: z.string().nullable(),
+});
+```
+- new_string:
+```ts
+export const PulseWireAphorismSchema = z.object({
+  id: z.string().nullable(),
+  author: z.string().nullable(),
+  attribution_status: AttributionStatusSchema.nullable(),
+  slot_1: z.string(),
+  // BUG-DAILY-001: consolidated impulse text. Server combines legacy
+  // slot_2 + slot_3 rows into this field at read time. New rows write
+  // only impulse_text (mirrored to slot_2 in DB for column reuse).
+  // Component prefers impulse_text; slot_2 / slot_3 stay in the schema
+  // for back-compat with cached rows during the transition.
+  impulse_text: z.string().nullable(),
+  slot_2: z.string().nullable(),
+  slot_3: z.string().nullable(),
+});
+```
+
+**Step 2.2: Server — update prompt + response shape**
+
+Find `buildSlotPrompt` in `server/services/tagespuls.service.mjs`:
+
+```bash
+grep -n "buildSlotPrompt\|slot_2.*slot_3\|JSON.*Schema" server/services/tagespuls.service.mjs | head -10
+```
+
+Use Edit to update the prompt's CONTEXT and SLOT instructions:
+
+- old_string:
+```
+SLOT 2 (Brücke ins Heute):
+- 10-20 Wörter, max 25
+- Du-Form, Alltags-Deutsch (or "you" form for English)
+- Anchor: a concrete situation, an inner state, OR an observation cue — pick ONE
+- Verboten: Zodiac-Name, Grad, Haus, Aspekt, BaZi-Insider-Wort, Element-Name in slot_2,
+  direkte Archetyp-Anrede, Wertung des Tages (gut/schlecht), Wiederholung des Aphorismus
+
+SLOT 3 (Handlungsimpuls):
+- 10-15 Wörter, max 20
+- Verb-getrieben, offener Ausgang, kein Versprechen
+- Erlaubte Formen: Imperativ / Frage / Beobachtungs-Vorschlag / Bedingungs-Satz
+- Verboten: Affirmation ("Du schaffst das"), Ermächtigungsfloskel, Warnung ("Vorsicht vor")
+
+MODUS-SCHÄRFE:
+- pulse:    tragend, sensorisch, einladend
+- trace:    direkt, geladen, "etwas passiert heute"
+- spannung: zwei Bewegungen in zeitlicher Abfolge ("zuerst… dann…")
+
+Output STRICT JSON only. No markdown, no commentary. Schema:
+{
+  "slot_2": "string",
+  "slot_3": "string"
+}
+```
+
+- new_string:
+```
+IMPULSE_TEXT (single consolidated paragraph — no internal labels):
+- 25-50 Wörter, 2-3 Sätze, EIN zusammenhängender Absatz
+- Du-Form, Alltags-Deutsch (or "you" form for English)
+- Webe drei Elemente in einen FLIESSENDEN Text:
+  * Brücke ins Heute (concrete situation, inner state, or observation cue)
+  * Handlungsimpuls (verb-driven, open-ended, no promise)
+  * (Aphorismus-Kontext semantisch fortgeführt, nicht zitiert)
+- Verboten:
+  * Strukturmarker im Output ("Brücke:", "Impuls:", "Heute:", numbered lists)
+  * Zodiac-Name, Grad, Haus, Aspekt, BaZi-Insider-Wort
+  * Element-Name (Holz/Wasser etc.) im Bridge-Teil
+  * Direkte Archetyp-Anrede ("Du Mond", "Liebe Sonne")
+  * Wertung des Tages (gut/schlecht)
+  * Wiederholung des Aphorismus
+  * Affirmation ("Du schaffst das"), Pinterest-Esoterik
+  * Warnung ("Vorsicht vor")
+
+MODUS-SCHÄRFE:
+- pulse:    tragend, sensorisch, einladend
+- trace:    direkt, geladen, "etwas passiert heute"
+- spannung: zwei Bewegungen in zeitlicher Abfolge ("zuerst… dann…")
+
+Output STRICT JSON only. No markdown, no commentary. Schema:
+{
+  "impulse_text": "string"
+}
+```
+
+**Step 2.3: Server — update parsing in `generateTagespulsSlots`**
+
+Find the function in `server.mjs`:
+
+```bash
+grep -n "generateTagespulsSlots\|parsed\\?\\.slot_2" server.mjs | head -5
+```
+
+Use Edit:
+
+- old_string:
+```js
+    const parsed = JSON.parse(jsonStr);
+    const slot2 = typeof parsed?.slot_2 === 'string' ? parsed.slot_2.trim() : null;
+    const slot3 = typeof parsed?.slot_3 === 'string' ? parsed.slot_3.trim() : null;
+    return {
+      slot_2: slot2 && slot2.length > 0 ? slot2 : null,
+      slot_3: slot3 && slot3.length > 0 ? slot3 : null,
+    };
+```
+
+- new_string:
+```js
+    const parsed = JSON.parse(jsonStr);
+    // BUG-DAILY-001: prompt now produces single impulse_text. Back-compat:
+    // if the model still emits the old slot_2/slot_3 shape (warm cache,
+    // older prompt), join them with a space.
+    const impulseText =
+      typeof parsed?.impulse_text === 'string'
+        ? parsed.impulse_text.trim()
+        : (typeof parsed?.slot_2 === 'string' && typeof parsed?.slot_3 === 'string'
+            ? `${parsed.slot_2.trim()} ${parsed.slot_3.trim()}`
+            : null);
+    return {
+      // Mirror to slot_2 column for DB column reuse — the schema-level
+      // migration to a dedicated impulse_text column is deferred.
+      slot_2: impulseText && impulseText.length > 0 ? impulseText : null,
+      slot_3: null,
+    };
+```
+
+**Step 2.4: Server — derive `impulse_text` in API response**
+
+Find the `/api/daily-pulse` response construction in `server.mjs`. Look for the `aphorism: { ... slot_2, slot_3 }` blocks (there are two: cached path + fresh-generation path).
+
+For BOTH blocks, add `impulse_text`:
+
+- old_string (cached path, around line 3127-3163):
+```js
+        aphorism: aphRow
+          ? {
+              id: aphRow.id,
+              author: aphRow.author,
+              attribution_status: aphRow.attribution_status,
+              slot_1: existing.slot_1,
+              slot_2: slot2,
+              slot_3: slot3,
+            }
+          : {
+              id: null,
+              author: null,
+              attribution_status: null,
+              slot_1: existing.slot_1,
+              slot_2: slot2,
+              slot_3: slot3,
+            },
+```
+
+- new_string:
+```js
+        aphorism: aphRow
+          ? {
+              id: aphRow.id,
+              author: aphRow.author,
+              attribution_status: aphRow.attribution_status,
+              slot_1: existing.slot_1,
+              // BUG-DAILY-001: consolidated text. New rows: slot_2 IS the
+              // consolidated text (slot_3 NULL). Legacy rows: join both.
+              impulse_text:
+                slot2 && slot3
+                  ? `${slot2} ${slot3}`
+                  : slot2 ?? null,
+              slot_2: slot2,
+              slot_3: slot3,
+            }
+          : {
+              id: null,
+              author: null,
+              attribution_status: null,
+              slot_1: existing.slot_1,
+              impulse_text:
+                slot2 && slot3
+                  ? `${slot2} ${slot3}`
+                  : slot2 ?? null,
+              slot_2: slot2,
+              slot_3: slot3,
+            },
+```
+
+For the fresh-generation path (around line 3222-3240):
+
+- old_string:
+```js
+      aphorism: {
+        id: aphorism.id,
+        author: aphorism.author,
+        attribution_status: aphorism.attribution_status,
+        slot_1: slot1,
+        slot_2: slot2,
+        slot_3: slot3,
+      },
+```
+
+- new_string:
+```js
+      aphorism: {
+        id: aphorism.id,
+        author: aphorism.author,
+        attribution_status: aphorism.attribution_status,
+        slot_1: slot1,
+        // BUG-DAILY-001: fresh rows write impulse_text into slot_2 (slot_3
+        // null), so impulse_text === slot_2 here. Kept distinct for the
+        // wire shape so future schema migration is non-breaking.
+        impulse_text: slot2 ?? null,
+        slot_2: slot2,
+        slot_3: slot3,
+      },
+```
+
+**Step 2.5: Component — replace 2-section render with single paragraph**
+
+Use Edit on `src/components/dashboard/TagespulsCard.tsx`:
+
+- old_string:
+```tsx
+      {/*
+        slot_2 / slot_3 are rendered ONLY when non-null. When the LLM
+        router returned null we omit the section entirely — the
+        no-placeholders directive forbids substituting generic copy.
+      */}
+      {aph.slot_2 && (
+        <div className="space-y-1" data-testid="tagespuls-bridge">
+          <span className="text-xs uppercase tracking-[0.2em] text-ink/55">
+            {t('tagespuls.bridge')}
+          </span>
+          <p className="text-sm text-ink/80 leading-relaxed">{aph.slot_2}</p>
+        </div>
+      )}
+
+      {aph.slot_3 && (
+        <div className="space-y-1" data-testid="tagespuls-impulse">
+          <span className="text-xs uppercase tracking-[0.2em] text-ink/55">
+            {t('tagespuls.impulse')}
+          </span>
+          <p className="text-sm text-ink/80 leading-relaxed">{aph.slot_3}</p>
+        </div>
+      )}
+```
+
+- new_string:
+```tsx
+      {/*
+        BUG-DAILY-001: consolidated impulse_text. The internal "Bridge to
+        today" / "Action impulse" labels were prompt structure, not
+        user-facing content — gone. The LLM weaves bridge + impulse + 
+        aphorism context into ONE natural paragraph.
+        
+        Back-compat: if a cached row only has slot_2 + slot_3 (pre-fix),
+        the server joins them at the API boundary so impulse_text is
+        always populated when ANY slot data exists.
+      */}
+      {aph.impulse_text && (
+        <p
+          className="text-sm text-ink/80 leading-relaxed"
+          data-testid="tagespuls-impulse-text"
+        >
+          {aph.impulse_text}
+        </p>
+      )}
+```
+
+**Step 2.6: i18n — delete bridge / impulse keys**
+
+```bash
+grep -n "    bridge:\|    impulse:" src/i18n/translations.ts
+```
+
+Should show 4 lines (DE + EN, each has both bridge and impulse).
+
+Use Edit FOUR times (one per line — they have different translations):
+
+For EN bridge:
+- old_string: `    bridge: "Bridge to today",\n`
+- new_string: ``
+
+For EN impulse:
+- old_string: `    impulse: "Action impulse",\n`
+- new_string: ``
+
+For DE bridge:
+- old_string: `    bridge: "Brücke ins Heute",\n`
+- new_string: ``
+
+For DE impulse:
+- old_string: `    impulse: "Handlungsimpuls",\n`
+- new_string: ``
+
+**Step 2.7: Run tests**
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx -t "TPC-NO-LABELS" 2>&1 | tail -10
+```
+
+Expected: 2 passing.
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx 2>&1 | tail -3
+npx vitest run server/__tests__/daily-pulse.test.mjs 2>&1 | tail -3
+npx vitest run src/__tests__/use-daily-pulse.test.ts 2>&1 | tail -3
+```
+
+Expected: tagespuls-card suite +2 (was N, now N+2). daily-pulse and use-daily-pulse may need fixture updates if they referenced `slot_2` directly.
+
+**Common breakage**: existing tests that asserted `screen.getByText(/Brücke ins Heute/)` or `getByTestId('tagespuls-bridge')` will fail. Update those tests to use the new testid `tagespuls-impulse-text`.
+
+**STOP and report** if more than 3 existing tests break — that means the legacy contract was broader than expected and the migration needs more thought.
+
+```bash
+npm run check:text-integrity 2>&1 | tail -3
+npx tsc --noEmit 2>&1 | tail -3
+```
+
+Expected: pass / clean.
+
+### Task 3: Commit
+
+```bash
+git add src/lib/schemas/daily-pulse.ts \
+        server.mjs \
+        server/services/tagespuls.service.mjs \
+        src/components/dashboard/TagespulsCard.tsx \
+        src/i18n/translations.ts \
+        src/__tests__/tagespuls-card.test.tsx \
+        server/__tests__/daily-pulse.test.mjs \
+        src/__tests__/use-daily-pulse.test.ts
+
+git commit -m "$(cat <<'EOF'
+fix(tagespuls): consolidate slot_2 + slot_3 into impulse_text, drop labels (BUG-DAILY-001, 002)
+
+Per 2026-05-10 product audit BUG-DAILY-001:
+"Bridge to today" / "Action impulse" were INTERNAL prompt labels —
+they leaked into user-facing UI as section headers above each slot.
+Spec: user sees a natural narrative paragraph integrating
+bridge + impulse + aphorism context, no internal structure visible.
+
+Per BUG-DAILY-002: the daily impulse must be at the top of the
+dashboard with the consolidated text (already top-mounted; this
+commit fixes the text shape).
+
+Architecture:
+
+1. Prompt change: LLM now produces a single { "impulse_text": "..." }
+   instead of { "slot_2", "slot_3" }. Rules block requires fluid
+   prose (25-50 words, 2-3 sentences, woven not labeled). Verbote
+   include "Brücke:" / "Impuls:" structure markers in output.
+
+2. Wire shape: PulseWireAphorismSchema gains `impulse_text:
+   string | null`. slot_2 / slot_3 stay in the schema for cached-row
+   back-compat. Server derives impulse_text:
+   - new rows: slot_2 IS the consolidated text, slot_3 NULL → 
+     impulse_text === slot_2
+   - legacy rows: slot_2 + slot_3 both populated → 
+     impulse_text = slot_2 + " " + slot_3
+
+3. Server response: both /api/daily-pulse paths (cached + fresh)
+   emit impulse_text alongside slot_2/slot_3 — wire is additive.
+
+4. Component: render single <p data-testid="tagespuls-impulse-text">
+   {aph.impulse_text}</p>. The two-section "tagespuls-bridge" /
+   "tagespuls-impulse" testids and their <span> labels are gone.
+
+5. i18n: tagespuls.bridge + tagespuls.impulse keys deleted from DE
+   and EN trees.
+
+6. Persistence parser: generateTagespulsSlots reads impulse_text
+   from JSON; if the model warm-caches the old shape, it joins
+   slot_2 + slot_3 with a space and stores in slot_2.
+
+Tests:
+- TPC-NO-LABELS-001: anti-label DOM walk (4 string checks + 2
+  testid checks). Asserts the consolidated text renders.
+- TPC-NO-LABELS-002: legacy 2-slot fixture renders consolidated,
+  raw slots NOT visible as separate sections.
+
+DB migration deferred — column reuse is sufficient for this fix.
+A future migration to a dedicated impulse_text column can deprecate
+slot_3 entirely once all cached rows have rolled.
+
+Closes 2026-05-10 audit BUG-DAILY-001, BUG-DAILY-002.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Do not push.** Stop after commit.
+
+---
+
+## Commit 2: BUG-003 + BUG-004 — Persistent decision lock on mount
+
+**Goal:** When user has already picked an archetype today, the dashboard renders Phase 2 IMMEDIATELY on mount — no Phase 1 flash, no chance to "pick again" via browser back / refresh / direct URL. Lock survives page reload, browser-back navigation, component re-render.
+
+### Architectural decisions
+
+1. **Server-side**: extend `GET /api/daily-pulse` response with `existing_decision: { archetype_key, text } | null`. Single roundtrip — no separate `/api/check-decision` endpoint.
+2. **Client-side**: `useDailyPulse` hook hydrates `selectedFigure` + `interpretationByKey` from `existing_decision` on mount. Phase 1 never renders if a decision exists.
+3. **No localStorage** — server is source of truth (already enforced by `daily_interpretations_one_per_pulse` UNIQUE constraint). localStorage caching adds drift risk.
+4. **History API**: NOT pushing state on selection. The server-side persistence + mount-time hydration is enough to defeat browser-back, since both forward and backward navigation re-mount the dashboard, which re-fetches `/api/daily-pulse`, which now includes `existing_decision`.
+
+### Task 4: RED — assert Phase 2 renders on mount when existing_decision is non-null
+
+**Files:**
+- Modify: `src/__tests__/use-daily-pulse.test.ts`
+
+```tsx
+  it('DPH-LOCK-MOUNT-001: hook hydrates Phase 2 state from existing_decision on mount', async () => {
+    // BUG-DAILY-003 / BUG-DAILY-004: when the user already picked today,
+    // /api/daily-pulse includes existing_decision. Hook initializes
+    // selectedFigure + interpretation IMMEDIATELY — no Phase 1 flash.
+    authedFetch.mockResolvedValueOnce(makeRes(200, {
+      ...VALID_PULSE,
+      aphorism: {
+        ...VALID_PULSE.aphorism,
+        impulse_text: 'consolidated text',
+        slot_2: null,
+        slot_3: null,
+      },
+      existing_decision: {
+        archetype_key: 'mond',
+        text: 'Locked Mond Libra deep interpretation',
+      },
+    }));
+    const useDailyPulse = await loadHook();
+
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Phase 2 state hydrated on mount, no second fetch needed
+    expect(result.current.selectedFigure).toBe('mond');
+    expect(result.current.interpretation?.text).toBe('Locked Mond Libra deep interpretation');
+    expect(result.current.interpretationError).toBeNull();
+    expect(authedFetch).toHaveBeenCalledTimes(1);  // ONLY /api/daily-pulse
+  });
+
+  it('DPH-LOCK-MOUNT-002: existing_decision=null → Phase 1 state (selectedFigure null)', async () => {
+    // Negative case: no decision yet → user can pick.
+    authedFetch.mockResolvedValueOnce(makeRes(200, {
+      ...VALID_PULSE,
+      aphorism: {
+        ...VALID_PULSE.aphorism,
+        impulse_text: 'consolidated',
+        slot_2: null,
+        slot_3: null,
+      },
+      existing_decision: null,
+    }));
+    const useDailyPulse = await loadHook();
+
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.selectedFigure).toBeNull();
+    expect(result.current.interpretation).toBeNull();
+  });
+```
+
+Run:
+
+```bash
+npx vitest run src/__tests__/use-daily-pulse.test.ts -t "DPH-LOCK-MOUNT" 2>&1 | tail -10
+```
+
+Expected: FAIL — hook doesn't read `existing_decision` yet.
+
+### Task 5: GREEN — schema, server, hook
+
+**Step 5.1: Schema — add `existing_decision` to `DailyPulseResponseSchema`**
+
+Use Edit on `src/lib/schemas/daily-pulse.ts`:
+
+- old_string:
+```ts
+export const DailyPulseResponseSchema = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  date: z.string(),
+  locale: z.enum(['de', 'en']),
+  mode: DayModeSchema,
+  intensity: z.number(),
+  harmony_index: z.number(),
+  aphorism: PulseWireAphorismSchema,
+  council: z.array(CouncilFigureSchema).length(6),
+  weather_stale: z.boolean(),
+});
+```
+
+- new_string:
+```ts
+export const ExistingDecisionSchema = z.object({
+  archetype_key: CouncilKeySchema,
+  text: z.string().min(1),
+});
+export type ExistingDecision = z.infer<typeof ExistingDecisionSchema>;
+
+export const DailyPulseResponseSchema = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  date: z.string(),
+  locale: z.enum(['de', 'en']),
+  mode: DayModeSchema,
+  intensity: z.number(),
+  harmony_index: z.number(),
+  aphorism: PulseWireAphorismSchema,
+  council: z.array(CouncilFigureSchema).length(6),
+  weather_stale: z.boolean(),
+  // BUG-DAILY-003 + 004: server includes the user's locked decision
+  // for today (if any) so the client can hydrate Phase 2 directly on
+  // mount, preventing browser-back / refresh from showing a stale
+  // Phase 1 with active selection buttons.
+  existing_decision: ExistingDecisionSchema.nullable(),
+});
+```
+
+**Step 5.2: Server — query existing decision in /api/daily-pulse**
+
+Find the response construction in `server.mjs` (both cached + fresh paths). Before each response construction, query for the user's existing decision today:
+
+Use Edit. Find the cached path's response payload assembly:
+
+After:
+```js
+    const interpretationCouncil = buildCouncilFromProfile(profileRow.astro_json);
+    const archetypeMatch = interpretationCouncil.find((c) => c.key === archetypeKey);
+    const signOrElement = archetypeMatch?.signOrElement ?? null;
+```
+
+Wait — that's the daily-interpretation handler. Let me locate the daily-pulse handler's payload assembly correctly.
+
+Search for:
+```bash
+grep -n "council: council,\|council: buildCouncilFromProfile\|/api/daily-pulse" server.mjs | head -10
+```
+
+The /api/daily-pulse handler builds two payloads (cached at line ~3127, fresh at ~3222). Both have `council: council,`. We need to add the existing_decision lookup BEFORE both, or once at the top of the handler.
+
+**Cleanest path**: do the lookup ONCE near the top of the handler (right after the auth + L1/L2 setup), then include it in both response paths.
+
+Find the handler's start:
+```bash
+grep -n "GET /api/daily-pulse\|app.get..api.daily-pulse" server.mjs | head -5
+```
+
+After the supabaseServer guard (around the place that loads the cached row), add the existing-decision lookup:
+
+```js
+    // BUG-DAILY-003 + 004: query the user's existing decision for this
+    // (user_id, date) so the client can hydrate Phase 2 immediately on
+    // mount, eliminating Phase 1 flash on browser-back / refresh.
+    //
+    // Scoped per (user, date) — same path as the I-3 cross-locale lock.
+    const { data: pulseIdsForDateRows } = await supabaseServer
+      .from('daily_pulses')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('date', date);
+    const allPulseIdsForDate = (pulseIdsForDateRows ?? []).map((p) => p.id);
+    let existingDecision = null;
+    if (allPulseIdsForDate.length > 0) {
+      const { data: decisionRow } = await supabaseServer
+        .from('daily_interpretations')
+        .select('selected_archetype_key, text')
+        .in('daily_pulse_id', allPulseIdsForDate)
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      if (decisionRow) {
+        existingDecision = {
+          archetype_key: decisionRow.selected_archetype_key,
+          text: decisionRow.text,
+        };
+      }
+    }
+```
+
+Then in BOTH the cached and fresh response construction blocks, add `existing_decision: existingDecision,` next to `weather_stale`:
+
+For the cached path:
+- old_string: `weather_stale: !!existing.weather_stale,`
+- new_string: `weather_stale: !!existing.weather_stale,\n        existing_decision: existingDecision,`
+
+For the fresh path:
+- old_string: `weather_stale: false,`
+- new_string: `weather_stale: false,\n      existing_decision: existingDecision,`
+
+(There may be multiple `weather_stale: false,` matches; use surrounding context to anchor on the right one — typically inside the `aphorism: { ... }` block's sibling.)
+
+**Step 5.3: Hook — hydrate state from existing_decision**
+
+Use Edit on `src/hooks/useDailyPulse.ts`. Find the success-parse block in the mount fetch effect:
+
+- old_string:
+```ts
+        const parsed = DailyPulseResponseSchema.safeParse(json);
+        if (!parsed.success) {
+          setError({ code: 'unknown' });
+          setPulse(null);
+          setLoading(false);
+          return;
+        }
+        setPulse(parsed.data);
+        setError(null);
+        setLoading(false);
+```
+
+- new_string:
+```ts
+        const parsed = DailyPulseResponseSchema.safeParse(json);
+        if (!parsed.success) {
+          setError({ code: 'unknown' });
+          setPulse(null);
+          setLoading(false);
+          return;
+        }
+        setPulse(parsed.data);
+        setError(null);
+        // BUG-DAILY-003 + 004: hydrate Phase 2 state from server's
+        // existing_decision so browser-back / refresh / direct URL
+        // load all show the locked Phase 2 immediately — no Phase 1
+        // flash with active selection buttons.
+        if (parsed.data.existing_decision) {
+          const { archetype_key, text } = parsed.data.existing_decision;
+          setSelectedFigure(archetype_key);
+          setInterpretationByKey((prev) => ({
+            ...prev,
+            [archetype_key]: { id: 'hydrated', text },
+          }));
+        }
+        setLoading(false);
+```
+
+**Step 5.4: Run tests**
+
+```bash
+npx vitest run src/__tests__/use-daily-pulse.test.ts -t "DPH-LOCK-MOUNT" 2>&1 | tail -10
+```
+
+Expected: 2 passing.
+
+```bash
+npx vitest run src/__tests__/use-daily-pulse.test.ts 2>&1 | tail -3
+npx vitest run server/__tests__/daily-pulse.test.mjs 2>&1 | tail -3
+npx vitest run src/__tests__/tagespuls-card.test.tsx 2>&1 | tail -3
+```
+
+**Probable breakage**: existing daily-pulse server tests don't mock the new `daily_pulses` lookup or `daily_interpretations` lookup. Their mockFetch may need to handle these calls (return empty arrays). Update those mocks to return `[]` for queries they didn't anticipate.
+
+```bash
+npx tsc --noEmit 2>&1 | tail -3
+```
+
+### Task 6: Commit
+
+```bash
+git add src/lib/schemas/daily-pulse.ts \
+        server.mjs \
+        src/hooks/useDailyPulse.ts \
+        src/__tests__/use-daily-pulse.test.ts \
+        server/__tests__/daily-pulse.test.mjs
+
+git commit -m "$(cat <<'EOF'
+fix(tagespuls): hydrate Phase 2 from existing_decision on mount (BUG-DAILY-003, 004)
+
+Per 2026-05-10 audit BUG-DAILY-003: browser-back navigation could
+re-render Phase 1 with active council buttons even after the user
+had already picked, because the hook fetched fresh /api/daily-pulse
+(which knew nothing about the existing decision) on every mount.
+The 409 lock only fired when the user re-clicked a button.
+
+Per BUG-DAILY-004: the lock state was ephemeral. Reload, browser
+history navigation, or any re-mount could re-show Phase 1
+momentarily.
+
+Architecture:
+
+1. Wire shape: DailyPulseResponseSchema gains
+   `existing_decision: { archetype_key, text } | null`. Server
+   queries daily_interpretations across all of the user's pulses
+   for today (cross-locale, per the I-3 fix).
+
+2. Hook: on successful /api/daily-pulse response, if
+   existing_decision is non-null, the hook IMMEDIATELY sets
+   selectedFigure + interpretationByKey before flipping loading off.
+   Component renders Phase 2 in the same render cycle that completes
+   the mount fetch — no Phase 1 flash.
+
+3. No client-side persistence (no localStorage). Server is the
+   source of truth (already enforced by
+   daily_interpretations_one_per_pulse UNIQUE). Adding localStorage
+   would create drift risk.
+
+Tests:
+- DPH-LOCK-MOUNT-001: existing_decision present → selectedFigure
+  + interpretation hydrated, no second fetch.
+- DPH-LOCK-MOUNT-002: existing_decision null → Phase 1 state
+  (selectedFigure null), unchanged behavior preserved.
+
+Existing tests asserting Phase 1 behavior unaffected — they pass
+existing_decision: null in fixtures or omit it (default null).
+
+Closes 2026-05-10 audit BUG-DAILY-003 + BUG-DAILY-004.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Commit 3: BUG-DAILY-005 — Daily impulse text persists in Phase 2
+
+**Goal:** When the user is in Phase 2 (figure selected, deep interpretation visible), the consolidated `impulse_text` from Phase 1 stays visible above the deep interpretation. Refresh / re-render keep both texts. The deep interpretation extends, doesn't replace.
+
+### Architectural decision
+
+Phase 2 layout becomes 4-block: aphorism → impulse_text → selected figure header → interpretation text. No new state — both texts come from the same `pulse` object that's already in the hook's state.
+
+### Task 7: RED — Phase 2 shows both texts
+
+**Files:**
+- Modify: `src/__tests__/tagespuls-card.test.tsx`
+
+```tsx
+  it('TPC-PHASE2-IMPULSE-001: Phase 2 keeps the consolidated impulse_text visible above the interpretation', () => {
+    // BUG-DAILY-005: deep interpretation EXTENDS, doesn't REPLACE.
+    // The general daily impulse text stays visible in Phase 2 so the
+    // user has both layers — the day's general framing AND the
+    // archetype-specific deep interpretation.
+    mockUseDailyPulse({
+      pulse: {
+        ...validPulseFixture,
+        aphorism: {
+          ...validPulseFixture.aphorism,
+          impulse_text: 'Heute trägt Mass mehr als der nächste Beweis. Schau hin, ohne sofort zu bewerten.',
+          slot_2: null,
+          slot_3: null,
+        },
+      },
+      selectedFigure: 'mond',
+      interpretation: { id: 'int-1', text: 'Dein Mond Libra zeigt heute eine ruhige Wachsamkeit.' },
+      loadingInterpretation: false,
+    });
+    render(<TagespulsCard />);
+
+    // BOTH texts visible
+    expect(screen.getByText(/Heute trägt Mass/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dein Mond Libra zeigt heute/i)).toBeInTheDocument();
+
+    // Anti-regression: still no internal labels
+    expect(screen.queryByText(/Brücke ins Heute|Bridge to today/)).not.toBeInTheDocument();
+  });
+
+  it('TPC-PHASE2-IMPULSE-002: Phase 2 with hydrated existing_decision (mount-time) also shows impulse_text', () => {
+    // Edge case: user lands on dashboard with an existing decision
+    // hydrated from the server (BUG-DAILY-003/004 fix). Phase 2 must
+    // still show the impulse_text — no flash, no missing daily framing.
+    mockUseDailyPulse({
+      pulse: {
+        ...validPulseFixture,
+        aphorism: {
+          ...validPulseFixture.aphorism,
+          impulse_text: 'consolidated impulse for today',
+          slot_2: null,
+          slot_3: null,
+        },
+      },
+      selectedFigure: 'sonne',
+      interpretation: { id: 'hydrated', text: 'Stier-Sonne deep interpretation hydrated from server' },
+      loadingInterpretation: false,
+    });
+    render(<TagespulsCard />);
+
+    expect(screen.getByText(/consolidated impulse for today/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stier-Sonne deep interpretation/i)).toBeInTheDocument();
+  });
+```
+
+Run:
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx -t "TPC-PHASE2-IMPULSE" 2>&1 | tail -10
+```
+
+Expected: FAIL — Phase 2 currently doesn't render `aph.impulse_text`.
+
+### Task 8: GREEN — Phase 2 layout includes impulse_text
+
+Use Edit on `src/components/dashboard/TagespulsCard.tsx`. Find the Phase 2 block (where `data-phase="interpretation"` is set):
+
+- old_string:
+```tsx
+        {/* Aphorism stays visible above the interpretation as the
+            curated foundation. After the user picks an archetype the
+            decision is irreversible (spec C-2: "Kein 'Zurück' Button"). */}
+        <blockquote className="border-l-2 border-gold/40 pl-4 text-base text-ink/85 italic">
+          "{aph.slot_1}"
+          {aph.author && (
+            <footer className="mt-1 text-xs not-italic text-ink/60">— {aph.author}</footer>
+          )}
+        </blockquote>
+
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium text-ink">
+```
+
+- new_string:
+```tsx
+        {/* Aphorism stays visible above the interpretation as the
+            curated foundation. After the user picks an archetype the
+            decision is irreversible (spec C-2: "Kein 'Zurück' Button"). */}
+        <blockquote className="border-l-2 border-gold/40 pl-4 text-base text-ink/85 italic">
+          "{aph.slot_1}"
+          {aph.author && (
+            <footer className="mt-1 text-xs not-italic text-ink/60">— {aph.author}</footer>
+          )}
+        </blockquote>
+
+        {/*
+          BUG-DAILY-005: deep interpretation EXTENDS, doesn't REPLACE.
+          The consolidated impulse_text stays visible so the user has
+          both layers — general daily framing + archetype-specific
+          deep interpretation.
+        */}
+        {aph.impulse_text && (
+          <p
+            className="text-sm text-ink/80 leading-relaxed"
+            data-testid="tagespuls-impulse-text-phase2"
+          >
+            {aph.impulse_text}
+          </p>
+        )}
+
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium text-ink">
+```
+
+Run tests:
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx -t "TPC-PHASE2-IMPULSE" 2>&1 | tail -10
+```
+
+Expected: 2 passing.
+
+```bash
+npx vitest run src/__tests__/tagespuls-card.test.tsx 2>&1 | tail -3
+npx tsc --noEmit 2>&1 | tail -3
+```
+
+### Task 9: Commit
+
+```bash
+git add src/components/dashboard/TagespulsCard.tsx src/__tests__/tagespuls-card.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(tagespuls): Phase 2 keeps impulse_text visible above interpretation (BUG-DAILY-005)
+
+Per 2026-05-10 audit BUG-DAILY-005: when the user enters Phase 2
+(after picking a figure), the daily impulse text disappeared and
+only the deep interpretation showed. Spec: deep interpretation
+EXTENDS, doesn't REPLACE — both layers visible.
+
+Phase 2 layout is now:
+  1. ← Andere Figur — REMOVED in C-2 fix
+  2. Aphorism (gold-bordered blockquote)
+  3. Impulse text (consolidated, no labels — BUG-DAILY-001)
+  4. Selected figure header
+  5. Deep interpretation paragraph
+
+The impulse_text comes from the same `pulse` object already in
+hook state — no new fetch, no new state. Refresh / re-render /
+mount-time-hydrated Phase 2 (BUG-DAILY-003/004) all preserve both
+texts.
+
+Tests:
+- TPC-PHASE2-IMPULSE-001: standard Phase 2 (post-click) shows both
+  impulse_text + interpretation, no labels.
+- TPC-PHASE2-IMPULSE-002: hydrated Phase 2 (mount-time) shows both
+  impulse_text + interpretation.
+
+Closes 2026-05-10 audit BUG-DAILY-005.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Commit 4: docs(plans) — record this plan
+
+```bash
+git add docs/plans/2026-05-10-tagespuls-bug-daily-001-005.md
+git commit -m "$(cat <<'EOF'
+docs(plans): tagespuls bug-daily-001-005 implementation plan
+
+Plan document driving the 3-commit fix-up of the 2026-05-10
+product audit findings on Tagesimpuls. Committed alongside
+implementation commits for traceability.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification + ship
+
+### Task 10: Full-suite + push + PR
+
+```bash
+npx vitest run 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | tail -3
+npm run check:text-integrity 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+
+Expected:
+- vitest: full suite green except 3 pre-existing failures (vibes-perf flake, EDF-NCP-003, api-daily-pulse idempotent — all documented)
+- tsc: clean
+- text-integrity: pass
+- build: succeeds
+
+```bash
+git push -u origin 2026-05-10-tagespuls-bug-daily-001-005
+
+gh pr create --base main --title "Tagespuls bug fixes — close 2026-05-10 audit (BUG-DAILY-001..005)" --body "$(cat <<'EOF'
+## Summary
+
+Closes the five user-reported bugs on the Tagesimpuls feature.
+
+| Commit | Bugs | Hash |
+|---|---|---|
+| 1. \`fix(tagespuls): consolidate slot_2 + slot_3 into impulse_text, drop labels\` | BUG-DAILY-001, 002 | (filled at PR time) |
+| 2. \`fix(tagespuls): hydrate Phase 2 from existing_decision on mount\` | BUG-DAILY-003, 004 | |
+| 3. \`fix(tagespuls): Phase 2 keeps impulse_text visible above interpretation\` | BUG-DAILY-005 | |
+| 4. \`docs(plans): tagespuls bug-daily-001-005 implementation plan\` | trail of intent | |
+
+## Highlights
+
+### BUG-001 + BUG-002 — Single consolidated text, no labels
+"Bridge to today" / "Action impulse" were INTERNAL prompt structure leaking into UI. LLM now produces ONE woven paragraph; component renders single \`<p>\` with no headers. Wire shape: new \`aphorism.impulse_text\` field; legacy \`slot_2\`/\`slot_3\` stay for cached-row back-compat. DB column reuse — no migration.
+
+### BUG-003 + BUG-004 — Persistent lock on mount
+\`/api/daily-pulse\` now includes \`existing_decision: { archetype_key, text } | null\`. Hook hydrates Phase 2 state IMMEDIATELY on mount when present — no Phase 1 flash, no chance to "pick again" via browser back. No localStorage; server is source of truth.
+
+### BUG-005 — Phase 2 extends, doesn't replace
+Deep interpretation (Phase 2) now keeps the consolidated \`impulse_text\` visible above the figure-specific interpretation. Both layers always shown.
+
+## Test plan
+
+- [ ] \`npm test\` — full suite green except pre-existing flakes
+- [ ] \`npx tsc --noEmit\` — clean
+- [ ] \`npm run build\` — OK
+- [ ] Manual smoke after Railway redeploy:
+  - Land on dashboard fresh: see impulse_text as ONE paragraph (no "Brücke ins Heute" / "Handlungsimpuls" headers)
+  - Pick a figure: deep interpretation appears BELOW the impulse_text (not replacing it)
+  - Browser back: stays on Phase 2 with locked decision (no Phase 1 with active buttons)
+  - Refresh: Phase 2 renders immediately from server hydration, no flicker
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Done-when checklist
+
+- [ ] Commit 1 (BUG-001, 002): TPC-NO-LABELS-001/002 pass; tagespuls-card suite green
+- [ ] Commit 2 (BUG-003, 004): DPH-LOCK-MOUNT-001/002 pass; existing tests adapted to new schema field
+- [ ] Commit 3 (BUG-005): TPC-PHASE2-IMPULSE-001/002 pass
+- [ ] Commit 4 (plan): plan doc committed
+- [ ] tsc clean throughout
+- [ ] build succeeds throughout
+- [ ] PR opened on main with all 4 commits visible
+
+## Out of scope (deliberate)
+
+- **DB schema migration** to a dedicated `impulse_text` column. Column reuse on `slot_2` is sufficient. A migration that drops `slot_3` and renames `slot_2` to `impulse_text` is a future hygiene task (purely cosmetic — wire shape already presents the new contract).
+- **06:00-local-time daily rollover** (BUG-DAILY-004 AC #6). The current system uses UTC date for `daily_pulses` keying. A timezone-aware date rollover (06:00 user-local) requires a separate spec discussion (which timezone? `Intl.DateTimeFormat`? user's birth_data timezone?). Document in the plan, ship the daily-keyed lock, defer the exact 06:00 cutoff.
+- **"Explore" feature** (BUG-DAILY-002 AC #4: "Explore kann den Text erneut oder vertieft anzeigen"). No "Explore" UI exists today; the spec implies a future expand-text button or modal. Out of scope for this fix; the persistent text + stable Phase 2 enable that future work.
+- **History API \`pushState\` on selection**. Browser-back is solved by mount-time hydration (server returns existing_decision). \`pushState\` would add a new history entry and complicate other navigation flows. Skip unless the audit re-flags this.
+
+## References
+
+- Source audit (this session, 2026-05-10): 5 user-reported bugs on Tagesimpuls
+- Implementation depends on: PRs #335 + #336 (already merged)
+- Related plan: \`docs/plans/2026-05-09-tagespuls-strict-rules.md\` (parent C-1..C-3 + I-1 work)
+- Related plan: \`docs/plans/2026-05-09-tagespuls-followup-findings.md\` (parent I-1..I-4 + M-1, M-3..M-5 review fixes)

--- a/server.mjs
+++ b/server.mjs
@@ -3010,11 +3010,20 @@ async function generateTagespulsSlots({ aphorism, mode, intensity, locale, harmo
     if (!jsonStr) return { slot_2: null, slot_3: null };
 
     const parsed = JSON.parse(jsonStr);
-    const slot2 = typeof parsed?.slot_2 === 'string' ? parsed.slot_2.trim() : null;
-    const slot3 = typeof parsed?.slot_3 === 'string' ? parsed.slot_3.trim() : null;
+    // BUG-DAILY-001: prompt now produces single impulse_text. Back-compat:
+    // if the model still emits the old slot_2/slot_3 shape (warm cache,
+    // older prompt), join them with a space.
+    const impulseText =
+      typeof parsed?.impulse_text === 'string'
+        ? parsed.impulse_text.trim()
+        : (typeof parsed?.slot_2 === 'string' && typeof parsed?.slot_3 === 'string'
+            ? `${parsed.slot_2.trim()} ${parsed.slot_3.trim()}`
+            : null);
     return {
-      slot_2: slot2 && slot2.length > 0 ? slot2 : null,
-      slot_3: slot3 && slot3.length > 0 ? slot3 : null,
+      // Mirror to slot_2 column for DB column reuse — the schema-level
+      // migration to a dedicated impulse_text column is deferred.
+      slot_2: impulseText && impulseText.length > 0 ? impulseText : null,
+      slot_3: null,
     };
   } catch (err) {
     console.warn('[daily-pulse] slot_2/3 generation failed:', err?.message || err?.code || err);
@@ -3092,8 +3101,11 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
       let slot3 = existing.slot_3;
       let updated = false;
 
-      // Re-attempt slot generation only when at least one is null.
-      if ((!slot2 || !slot3) && aphRow) {
+      // BUG-DAILY-001: re-attempt only when the consolidated text is
+      // truly missing (slot_2 null). New rows: slot_3 is permanently
+      // null by design — its presence/absence no longer signals an
+      // incomplete row.
+      if (!slot2 && aphRow) {
         const generated = await generateTagespulsSlots({
           aphorism: aphRow,
           mode: existing.mode,
@@ -3101,9 +3113,9 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
           locale,
           harmony,
         });
-        if (generated.slot_2 && generated.slot_3) {
+        if (generated.slot_2) {
           slot2 = generated.slot_2;
-          slot3 = generated.slot_3;
+          slot3 = generated.slot_3; // null on new prompt path
           updated = true;
         }
       }
@@ -3140,6 +3152,12 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
               author: aphRow.author,
               attribution_status: aphRow.attribution_status,
               slot_1: existing.slot_1,
+              // BUG-DAILY-001: consolidated text. New rows: slot_2 IS the
+              // consolidated text (slot_3 NULL). Legacy rows: join both.
+              impulse_text:
+                slot2 && slot3
+                  ? `${slot2} ${slot3}`
+                  : slot2 ?? null,
               slot_2: slot2,
               slot_3: slot3,
             }
@@ -3148,6 +3166,10 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
               author: null,
               attribution_status: null,
               slot_1: existing.slot_1,
+              impulse_text:
+                slot2 && slot3
+                  ? `${slot2} ${slot3}`
+                  : slot2 ?? null,
               slot_2: slot2,
               slot_3: slot3,
             },
@@ -3155,9 +3177,11 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
         weather_stale: !!existing.weather_stale,
       };
 
-      // Only cache to L1 when both slots are populated — never lock the
-      // user into a partial state.
-      if (slot2 && slot3) {
+      // BUG-DAILY-001: cache when consolidated impulse text is present.
+      // New rows: slot_2 IS the consolidated text, slot_3 NULL.
+      // Legacy rows: both slot_2 + slot_3 populated. Either way, slot_2
+      // truthy ⇒ the row has user-facing content and is safe to cache.
+      if (slot2) {
         dailyPulseCache.set(cacheKey, { ts: Date.now(), payload });
       }
 
@@ -3209,8 +3233,10 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
       return res.status(500).json({ error: { code: 'PERSIST_FAILED' } });
     }
 
-    // Track usage only when the row is complete — cooldown is honest.
-    if (slot2 && slot3) {
+    // BUG-DAILY-001: track usage when consolidated text is present.
+    // slot_3 is permanently null on new rows; slot_2 truthy ⇒ row is
+    // "complete" by the new definition. Cooldown remains honest.
+    if (slot2) {
       await supabaseServer
         .from('aphorism_usage_events')
         .upsert({
@@ -3234,6 +3260,10 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
         author: aphorism.author,
         attribution_status: aphorism.attribution_status,
         slot_1: slot1,
+        // BUG-DAILY-001: fresh rows write impulse_text into slot_2
+        // (slot_3 null), so impulse_text === slot_2 here. Kept distinct
+        // for the wire shape so a future schema migration is non-breaking.
+        impulse_text: slot2 ?? null,
         slot_2: slot2,
         slot_3: slot3,
       },
@@ -3241,7 +3271,8 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
       weather_stale: false,
     };
 
-    if (slot2 && slot3) {
+    // BUG-DAILY-001: cache once consolidated text is present.
+    if (slot2) {
       dailyPulseCache.set(cacheKey, { ts: Date.now(), payload });
     }
 

--- a/server.mjs
+++ b/server.mjs
@@ -3086,6 +3086,33 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
     }
     const council = buildCouncilFromProfile(profileRow.astro_json);
 
+    // BUG-DAILY-003 + 004: query the user's existing decision for this
+    // (user_id, date). Cross-locale scoped so locale-switching can't
+    // bypass the lock — same path as PR #336's I-3 fix. Single roundtrip
+    // avoids a separate /api/check-decision endpoint.
+    const { data: pulseIdsForDateRows } = await supabaseServer
+      .from('daily_pulses')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('date', date);
+    const allPulseIdsForDate = (pulseIdsForDateRows ?? []).map((p) => p.id);
+    let existingDecision = null;
+    if (allPulseIdsForDate.length > 0) {
+      const { data: decisionRow } = await supabaseServer
+        .from('daily_interpretations')
+        .select('selected_archetype_key, text')
+        .in('daily_pulse_id', allPulseIdsForDate)
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      if (decisionRow) {
+        existingDecision = {
+          archetype_key: decisionRow.selected_archetype_key,
+          text: decisionRow.text,
+        };
+      }
+    }
+
     // L2 hit: serve as-is when slots present, otherwise re-attempt slot generation.
     if (existing) {
       // Look up the aphorism row for the response (status, attribution).
@@ -3175,6 +3202,7 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
             },
         council,
         weather_stale: !!existing.weather_stale,
+        existing_decision: existingDecision,
       };
 
       // BUG-DAILY-001: cache when consolidated impulse text is present.
@@ -3269,6 +3297,7 @@ app.get('/api/daily-pulse', requireUserAuth, async (req, res) => {
       },
       council,
       weather_stale: false,
+      existing_decision: existingDecision,
     };
 
     // BUG-DAILY-001: cache once consolidated text is present.

--- a/server/__tests__/daily-pulse.test.mjs
+++ b/server/__tests__/daily-pulse.test.mjs
@@ -217,12 +217,14 @@ describe('GET /api/daily-pulse — no-placeholders contract', () => {
     vi.restoreAllMocks();
   });
 
-  it('DPL-001: happy path — profile + AI succeed → 200 with aphorism + slots + council', async () => {
+  it('DPL-001: happy path — profile + AI succeed → 200 with aphorism + impulse_text + council', async () => {
+    // BUG-DAILY-001: prompt now emits a single { "impulse_text": "..." }
+    // shape. Server mirrors it into slot_2 (DB column reuse) and exposes
+    // it as impulse_text on the wire.
     mockFetch();
-    const slots = JSON.stringify({
-      slot_2: 'Du weißt heute mehr über deine Lage, als du dir zugestehst.',
-      slot_3: 'Schau hin, ohne sofort zu bewerten.',
-    });
+    const consolidated =
+      'Du weißt heute mehr über deine Lage, als du dir zugestehst. Schau hin, ohne sofort zu bewerten.';
+    const slots = JSON.stringify({ impulse_text: consolidated });
     const app = await loadApp(makeGeminiTextMock(slots));
 
     const res = await request(app)
@@ -231,8 +233,11 @@ describe('GET /api/daily-pulse — no-placeholders contract', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.aphorism.slot_1).toBe(APHORISM_ROW.text_de);
-    expect(res.body.aphorism.slot_2).toBe('Du weißt heute mehr über deine Lage, als du dir zugestehst.');
-    expect(res.body.aphorism.slot_3).toBe('Schau hin, ohne sofort zu bewerten.');
+    // Wire shape: impulse_text is the consolidated paragraph.
+    expect(res.body.aphorism.impulse_text).toBe(consolidated);
+    // Back-compat: slot_2 mirrors impulse_text, slot_3 is null.
+    expect(res.body.aphorism.slot_2).toBe(consolidated);
+    expect(res.body.aphorism.slot_3).toBeNull();
     expect(res.body.aphorism.author).toBe('Anonymous');
     expect(res.body.mode).toBe('trace'); // harmony 0.8711 >= 0.5
     expect(Array.isArray(res.body.council)).toBe(true);

--- a/server/services/tagespuls.service.mjs
+++ b/server/services/tagespuls.service.mjs
@@ -173,18 +173,22 @@ CONTEXT:
 - Aphorismus (slot_1): "${aphText}" — ${author}${work}
 - Output language: ${lang}
 
-SLOT 2 (Brücke ins Heute):
-- 10-20 Wörter, max 25
+IMPULSE_TEXT (single consolidated paragraph — no internal labels):
+- 25-50 Wörter, 2-3 Sätze, EIN zusammenhängender Absatz
 - Du-Form, Alltags-Deutsch (or "you" form for English)
-- Anchor: a concrete situation, an inner state, OR an observation cue — pick ONE
-- Verboten: Zodiac-Name, Grad, Haus, Aspekt, BaZi-Insider-Wort, Element-Name in slot_2,
-  direkte Archetyp-Anrede, Wertung des Tages (gut/schlecht), Wiederholung des Aphorismus
-
-SLOT 3 (Handlungsimpuls):
-- 10-15 Wörter, max 20
-- Verb-getrieben, offener Ausgang, kein Versprechen
-- Erlaubte Formen: Imperativ / Frage / Beobachtungs-Vorschlag / Bedingungs-Satz
-- Verboten: Affirmation ("Du schaffst das"), Ermächtigungsfloskel, Warnung ("Vorsicht vor")
+- Webe drei Elemente in einen FLIESSENDEN Text:
+  * Brücke ins Heute (concrete situation, inner state, or observation cue)
+  * Handlungsimpuls (verb-driven, open-ended, no promise)
+  * (Aphorismus-Kontext semantisch fortgeführt, nicht zitiert)
+- Verboten:
+  * Strukturmarker im Output ("Brücke:", "Impuls:", "Heute:", numbered lists)
+  * Zodiac-Name, Grad, Haus, Aspekt, BaZi-Insider-Wort
+  * Element-Name (Holz/Wasser etc.) im Bridge-Teil
+  * Direkte Archetyp-Anrede ("Du Mond", "Liebe Sonne")
+  * Wertung des Tages (gut/schlecht)
+  * Wiederholung des Aphorismus
+  * Affirmation ("Du schaffst das"), Pinterest-Esoterik
+  * Warnung ("Vorsicht vor")
 
 MODUS-SCHÄRFE:
 - pulse:    tragend, sensorisch, einladend
@@ -193,8 +197,7 @@ MODUS-SCHÄRFE:
 
 Output STRICT JSON only. No markdown, no commentary. Schema:
 {
-  "slot_2": "string",
-  "slot_3": "string"
+  "impulse_text": "string"
 }
 `.trim();
 }

--- a/src/__tests__/api-daily-pulse.test.ts
+++ b/src/__tests__/api-daily-pulse.test.ts
@@ -142,16 +142,18 @@ const APHORISM_ROW = {
   cooldown_days: 30,
 };
 
-const geminiSlotResponse = (slot_2 = 'Heute trägt dich Stille.', slot_3 = 'Bewege dich langsam.') =>
+const geminiSlotResponse = (
+  impulseText = 'Heute trägt dich Stille. Bewege dich langsam.',
+) =>
   ok({
     candidates: [
       {
         content: {
-          parts: [{ text: JSON.stringify({ slot_2, slot_3 }) }],
+          parts: [{ text: JSON.stringify({ impulse_text: impulseText }) }],
         },
       },
     ],
-    text: JSON.stringify({ slot_2, slot_3 }),
+    text: JSON.stringify({ impulse_text: impulseText }),
   });
 
 const geminiInterpretationResponse = (text = 'Ein klarer Moment für deine Sonne. ' + 'Lorem ipsum dolor sit amet, consectetur.') =>
@@ -295,8 +297,10 @@ describe('GET /api/daily-pulse', () => {
               harmony_index: HARMONY_TRACE,
               aphorism_id: APHORISM_ROW.id,
               slot_1: APHORISM_ROW.text_de,
-              slot_2: 'Heute trägt dich Stille.',
-              slot_3: 'Bewege dich langsam.',
+              // BUG-DAILY-001: server now writes consolidated text into
+              // slot_2 (slot_3 NULL). Mirrors the parser output.
+              slot_2: 'Heute trägt dich Stille. Bewege dich langsam.',
+              slot_3: null,
               weather_stale: false,
             });
           }
@@ -326,10 +330,13 @@ describe('GET /api/daily-pulse', () => {
     expect(supabaseCount.value).toBe(supabaseCallsAfterFirst);
   });
 
-  it('happy path: returns aphorism + slots + council', async () => {
+  it('happy path: returns aphorism + impulse_text + council', async () => {
+    // BUG-DAILY-001: prompt → { impulse_text }. Server mirrors it into
+    // slot_2 (DB column reuse), exposes it on the wire as impulse_text.
+    const consolidated = 'Heute trägt dich Stille. Bewege dich langsam.';
     const { app } = await loadTestApp();
     installFetch({
-      gemini: () => geminiSlotResponse('Heute trägt dich Stille.', 'Bewege dich langsam.'),
+      gemini: () => geminiSlotResponse(consolidated),
       table: {
         daily_pulses: (_url, init) => {
           // POST = .upsert().select().single() — returns single object directly.
@@ -344,8 +351,8 @@ describe('GET /api/daily-pulse', () => {
               harmony_index: HARMONY_TRACE,
               aphorism_id: APHORISM_ROW.id,
               slot_1: APHORISM_ROW.text_de,
-              slot_2: 'Heute trägt dich Stille.',
-              slot_3: 'Bewege dich langsam.',
+              slot_2: consolidated,
+              slot_3: null,
               weather_stale: false,
             });
           }
@@ -367,8 +374,10 @@ describe('GET /api/daily-pulse', () => {
     expect(res.body.mode).toBe('trace');
     expect(typeof res.body.intensity).toBe('number');
     expect(res.body.aphorism.slot_1).toBe(APHORISM_ROW.text_de);
-    expect(res.body.aphorism.slot_2).toBe('Heute trägt dich Stille.');
-    expect(res.body.aphorism.slot_3).toBe('Bewege dich langsam.');
+    expect(res.body.aphorism.impulse_text).toBe(consolidated);
+    // Back-compat: slot_2 mirrors impulse_text, slot_3 is null.
+    expect(res.body.aphorism.slot_2).toBe(consolidated);
+    expect(res.body.aphorism.slot_3).toBeNull();
     expect(Array.isArray(res.body.council)).toBe(true);
     expect(res.body.council).toHaveLength(6);
     const keys = res.body.council.map((c: { key: string }) => c.key);

--- a/src/__tests__/tagespuls-card.test.tsx
+++ b/src/__tests__/tagespuls-card.test.tsx
@@ -417,4 +417,57 @@ describe('TagespulsCard', () => {
     expect(screen.getByText(/Legacy bridge text\. Legacy action impulse text\./)).toBeInTheDocument();
     expect(screen.queryByTestId('tagespuls-bridge')).not.toBeInTheDocument();
   });
+
+  it('TPC-PHASE2-IMPULSE-001: Phase 2 keeps the consolidated impulse_text visible above the interpretation', () => {
+    // BUG-DAILY-005: deep interpretation EXTENDS, doesn't REPLACE.
+    // The general daily impulse text stays visible in Phase 2 so the
+    // user has both layers — the day's general framing AND the
+    // archetype-specific deep interpretation.
+    setHookState({
+      pulse: {
+        ...FULL_PULSE,
+        aphorism: {
+          ...FULL_PULSE.aphorism,
+          impulse_text: 'Heute trägt Mass mehr als der nächste Beweis. Schau hin, ohne sofort zu bewerten.',
+          slot_2: null,
+          slot_3: null,
+        },
+      },
+      selectedFigure: 'mond',
+      interpretation: { id: 'int-1', text: 'Dein Mond Libra zeigt heute eine ruhige Wachsamkeit.' },
+      loadingInterpretation: false,
+    });
+    render(<TagespulsCard />);
+
+    // BOTH texts visible
+    expect(screen.getByText(/Heute trägt Mass/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dein Mond Libra zeigt heute/i)).toBeInTheDocument();
+
+    // Anti-regression: still no internal labels
+    expect(screen.queryByText(/Brücke ins Heute|Bridge to today/)).not.toBeInTheDocument();
+  });
+
+  it('TPC-PHASE2-IMPULSE-002: Phase 2 with hydrated existing_decision (mount-time) also shows impulse_text', () => {
+    // Edge case: user lands on dashboard with an existing decision
+    // hydrated from the server (BUG-DAILY-003/004 fix). Phase 2 must
+    // still show the impulse_text — no flash, no missing daily framing.
+    setHookState({
+      pulse: {
+        ...FULL_PULSE,
+        aphorism: {
+          ...FULL_PULSE.aphorism,
+          impulse_text: 'consolidated impulse for today',
+          slot_2: null,
+          slot_3: null,
+        },
+      },
+      selectedFigure: 'sonne',
+      interpretation: { id: 'hydrated', text: 'Stier-Sonne deep interpretation hydrated from server' },
+      loadingInterpretation: false,
+    });
+    render(<TagespulsCard />);
+
+    expect(screen.getByText(/consolidated impulse for today/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stier-Sonne deep interpretation/i)).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/tagespuls-card.test.tsx
+++ b/src/__tests__/tagespuls-card.test.tsx
@@ -51,6 +51,10 @@ const FULL_PULSE: DailyPulseResponse = {
     author: 'Marcus Aurelius',
     attribution_status: 'verified',
     slot_1: 'Die Tage fließen, und nichts hält still.',
+    // BUG-DAILY-001: server combines slot_2 + slot_3 into impulse_text
+    // for legacy rows. Fixture mirrors the on-the-wire shape.
+    impulse_text:
+      'Du sitzt am Schreibtisch, der Kaffee dampft, und ein Gedanke schiebt sich vor. Schreib einen Satz auf, der den Tag öffnet.',
     slot_2: 'Du sitzt am Schreibtisch, der Kaffee dampft, und ein Gedanke schiebt sich vor.',
     slot_3: 'Schreib einen Satz auf, der den Tag öffnet.',
   },
@@ -119,7 +123,9 @@ describe('TagespulsCard', () => {
     expect(screen.getByTestId('tagespuls-card-skeleton')).toBeTruthy();
   });
 
-  it('TPC-002: real data renders aphorism + author + slot_2 + slot_3 + 6 council buttons', () => {
+  it('TPC-002: real data renders aphorism + author + impulse_text + 6 council buttons', () => {
+    // BUG-DAILY-001: slot_2 + slot_3 collapsed into single impulse_text
+    // section — no internal labels.
     setHookState({ pulse: FULL_PULSE });
     const { container } = render(<TagespulsCard />);
 
@@ -127,32 +133,37 @@ describe('TagespulsCard', () => {
     expect(container.textContent).toContain(FULL_PULSE.aphorism.slot_1);
     expect(container.textContent).toContain('Marcus Aurelius');
 
-    // Slot 2 and 3 visible
-    expect(screen.getByTestId('tagespuls-bridge')).toBeTruthy();
-    expect(screen.getByTestId('tagespuls-impulse')).toBeTruthy();
-    expect(container.textContent).toContain(FULL_PULSE.aphorism.slot_2);
-    expect(container.textContent).toContain(FULL_PULSE.aphorism.slot_3);
+    // Consolidated impulse text visible (no internal Bridge/Impulse labels)
+    expect(screen.getByTestId('tagespuls-impulse-text')).toBeTruthy();
+    expect(container.textContent).toContain(FULL_PULSE.aphorism.impulse_text);
+    // Old testids gone
+    expect(screen.queryByTestId('tagespuls-bridge')).toBeNull();
+    expect(screen.queryByTestId('tagespuls-impulse')).toBeNull();
 
     // 6 council buttons rendered
     const buttons = container.querySelectorAll('[data-figure-key]');
     expect(buttons).toHaveLength(6);
   });
 
-  it('TPC-003: slot_2 = null → bridge section omitted, NO placeholder text leaks', () => {
+  it('TPC-003: impulse_text null → impulse section omitted, NO placeholder text leaks', () => {
+    // BUG-DAILY-001: when the LLM router fails, impulse_text is null
+    // and the section is omitted entirely. No fallback copy injected.
     setHookState({
       pulse: {
         ...FULL_PULSE,
-        aphorism: { ...FULL_PULSE.aphorism, slot_2: null },
+        aphorism: { ...FULL_PULSE.aphorism, impulse_text: null, slot_2: null, slot_3: null },
       },
     });
     const { container } = render(<TagespulsCard />);
 
-    // The bridge subsection is entirely absent.
+    // The impulse subsection is entirely absent.
+    expect(screen.queryByTestId('tagespuls-impulse-text')).toBeNull();
+    // No legacy bridge/impulse testids either.
     expect(screen.queryByTestId('tagespuls-bridge')).toBeNull();
-    // The bridge label key is NOT rendered.
+    expect(screen.queryByTestId('tagespuls-impulse')).toBeNull();
+    // The internal label keys are NOT rendered.
     expect(container.textContent).not.toContain('tagespuls.bridge');
-    // The slot_3 section is unaffected — still rendered.
-    expect(screen.getByTestId('tagespuls-impulse')).toBeTruthy();
+    expect(container.textContent).not.toContain('tagespuls.impulse');
     // Aphorism is still visible.
     expect(container.textContent).toContain(FULL_PULSE.aphorism.slot_1);
     // No fallback strings.
@@ -349,5 +360,61 @@ describe('TagespulsCard', () => {
     for (const b of buttons) {
       expect(b.hasAttribute('disabled')).toBe(true);
     }
+  });
+
+  it('TPC-NO-LABELS-001: no internal Bridge/Impulse labels appear in Phase 1', () => {
+    // BUG-DAILY-001: "Bridge to today" / "Action impulse" are internal
+    // prompt labels and must never appear in user-facing UI.
+    setHookState({
+      pulse: {
+        ...FULL_PULSE,
+        aphorism: {
+          ...FULL_PULSE.aphorism,
+          impulse_text: 'Heute trägt Mass mehr als der nächste Beweis. Schau hin, ohne sofort zu bewerten.',
+          slot_2: null,
+          slot_3: null,
+        },
+      },
+      selectedFigure: null,
+    });
+    render(<TagespulsCard />);
+
+    // Anti-label DOM walk — neither EN nor DE label may appear
+    expect(screen.queryByText(/Bridge to today/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Brücke ins Heute/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Action impulse/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Handlungsimpuls/i)).not.toBeInTheDocument();
+
+    // The consolidated impulse text IS rendered
+    expect(screen.getByText(/Heute trägt Mass/i)).toBeInTheDocument();
+
+    // Old testids gone, new testid present
+    expect(screen.queryByTestId('tagespuls-bridge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tagespuls-impulse')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tagespuls-impulse-text')).toBeInTheDocument();
+  });
+
+  it('TPC-NO-LABELS-002: legacy 2-slot row renders consolidated text only (server-side joined)', () => {
+    // Backward compat: cached rows from before this fix have both
+    // slot_2 and slot_3 populated. The server normalizes to
+    // impulse_text BEFORE returning. Component renders impulse_text
+    // only, never the raw slots as separate sections.
+    setHookState({
+      pulse: {
+        ...FULL_PULSE,
+        aphorism: {
+          ...FULL_PULSE.aphorism,
+          impulse_text: 'Legacy bridge text. Legacy action impulse text.',
+          slot_2: 'Legacy bridge text.',
+          slot_3: 'Legacy action impulse text.',
+        },
+      },
+      selectedFigure: null,
+    });
+    render(<TagespulsCard />);
+
+    expect(screen.queryByText(/Bridge to today|Brücke ins Heute|Action impulse|Handlungsimpuls/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Legacy bridge text\. Legacy action impulse text\./)).toBeInTheDocument();
+    expect(screen.queryByTestId('tagespuls-bridge')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/use-daily-pulse.test.ts
+++ b/src/__tests__/use-daily-pulse.test.ts
@@ -54,6 +54,9 @@ const VALID_PULSE = {
     { key: 'wuxing_dom', displayName: 'Wu-Xing dominant', signOrElement: 'Holz' },
   ],
   weather_stale: false,
+  // BUG-DAILY-003 + 004: default fixture state is "no decision yet".
+  // Tests that need a hydrated Phase 2 override this via spread.
+  existing_decision: null,
 };
 
 function makeRes(status: number, body: unknown, headers: Record<string, string> = {}): Response {
@@ -338,5 +341,44 @@ describe('useDailyPulse', () => {
 
     expect(result.current.interpretation).toBeNull();
     expect(result.current.interpretationError?.code).toBe('unknown');
+  });
+
+  // ── BUG-DAILY-003 + 004: persistent decision lock on mount ────────────────
+  it('DPH-LOCK-MOUNT-001: hook hydrates Phase 2 state from existing_decision on mount', async () => {
+    // BUG-DAILY-003 / BUG-DAILY-004: when the user already picked today,
+    // /api/daily-pulse includes existing_decision. Hook initializes
+    // selectedFigure + interpretation IMMEDIATELY — no Phase 1 flash.
+    authedFetch.mockResolvedValueOnce(makeRes(200, {
+      ...VALID_PULSE,
+      existing_decision: {
+        archetype_key: 'mond',
+        text: 'Locked Mond Libra deep interpretation',
+      },
+    }));
+    const useDailyPulse = await loadHook();
+
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Phase 2 state hydrated on mount, no second fetch needed
+    expect(result.current.selectedFigure).toBe('mond');
+    expect(result.current.interpretation?.text).toBe('Locked Mond Libra deep interpretation');
+    expect(result.current.interpretationError).toBeNull();
+    expect(authedFetch).toHaveBeenCalledTimes(1);  // ONLY /api/daily-pulse
+  });
+
+  it('DPH-LOCK-MOUNT-002: existing_decision=null → Phase 1 state (selectedFigure null)', async () => {
+    // Negative case: no decision yet → user can pick.
+    authedFetch.mockResolvedValueOnce(makeRes(200, {
+      ...VALID_PULSE,
+      existing_decision: null,
+    }));
+    const useDailyPulse = await loadHook();
+
+    const { result } = renderHook(() => useDailyPulse('de'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.selectedFigure).toBeNull();
+    expect(result.current.interpretation).toBeNull();
   });
 });

--- a/src/__tests__/use-daily-pulse.test.ts
+++ b/src/__tests__/use-daily-pulse.test.ts
@@ -38,6 +38,10 @@ const VALID_PULSE = {
     author: 'Marcus Aurelius',
     attribution_status: 'verified' as const,
     slot_1: 'Die Tage fließen, und nichts hält still.',
+    // BUG-DAILY-001: consolidated text on the wire. slot_2/slot_3
+    // remain populated for back-compat with cached rows.
+    impulse_text:
+      'Du sitzt am Schreibtisch, der Kaffee dampft, und ein Gedanke schiebt sich vor. Schreib einen Satz auf, der den Tag öffnet.',
     slot_2: 'Du sitzt am Schreibtisch, der Kaffee dampft, und ein Gedanke schiebt sich vor.',
     slot_3: 'Schreib einen Satz auf, der den Tag öffnet.',
   },
@@ -229,11 +233,18 @@ describe('useDailyPulse', () => {
     expect(result.current.interpretation).toBeNull();
   });
 
-  it('DPH-008: response with null slot_2/slot_3 still parses cleanly', async () => {
+  it('DPH-008: response with null impulse_text/slot_2/slot_3 still parses cleanly', async () => {
+    // BUG-DAILY-001: AI exhaustion → impulse_text is null. The hook
+    // must parse the response without error and surface the null state.
     authedFetch.mockResolvedValueOnce(
       makeRes(200, {
         ...VALID_PULSE,
-        aphorism: { ...VALID_PULSE.aphorism, slot_2: null, slot_3: null },
+        aphorism: {
+          ...VALID_PULSE.aphorism,
+          impulse_text: null,
+          slot_2: null,
+          slot_3: null,
+        },
       }),
     );
     const useDailyPulse = await loadHook();
@@ -243,6 +254,7 @@ describe('useDailyPulse', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.pulse?.aphorism.slot_1).toBeTruthy();
+    expect(result.current.pulse?.aphorism.impulse_text).toBeNull();
     expect(result.current.pulse?.aphorism.slot_2).toBeNull();
     expect(result.current.pulse?.aphorism.slot_3).toBeNull();
   });

--- a/src/components/dashboard/TagespulsCard.tsx
+++ b/src/components/dashboard/TagespulsCard.tsx
@@ -310,26 +310,22 @@ export function TagespulsCard({ onCompleteProfile }: TagespulsCardProps) {
       </blockquote>
 
       {/*
-        slot_2 / slot_3 are rendered ONLY when non-null. When the LLM
-        router returned null we omit the section entirely — the
-        no-placeholders directive forbids substituting generic copy.
-      */}
-      {aph.slot_2 && (
-        <div className="space-y-1" data-testid="tagespuls-bridge">
-          <span className="text-xs uppercase tracking-[0.2em] text-ink/55">
-            {t('tagespuls.bridge')}
-          </span>
-          <p className="text-sm text-ink/80 leading-relaxed">{aph.slot_2}</p>
-        </div>
-      )}
+        BUG-DAILY-001: consolidated impulse_text. The internal "Bridge to
+        today" / "Action impulse" labels were prompt structure, not
+        user-facing content — gone. The LLM weaves bridge + impulse +
+        aphorism context into ONE natural paragraph.
 
-      {aph.slot_3 && (
-        <div className="space-y-1" data-testid="tagespuls-impulse">
-          <span className="text-xs uppercase tracking-[0.2em] text-ink/55">
-            {t('tagespuls.impulse')}
-          </span>
-          <p className="text-sm text-ink/80 leading-relaxed">{aph.slot_3}</p>
-        </div>
+        Back-compat: if a cached row only has slot_2 + slot_3 (pre-fix),
+        the server joins them at the API boundary so impulse_text is
+        always populated when ANY slot data exists.
+      */}
+      {aph.impulse_text && (
+        <p
+          className="text-sm text-ink/80 leading-relaxed"
+          data-testid="tagespuls-impulse-text"
+        >
+          {aph.impulse_text}
+        </p>
       )}
 
       <div className="pt-2 space-y-3" data-testid="tagespuls-council">

--- a/src/components/dashboard/TagespulsCard.tsx
+++ b/src/components/dashboard/TagespulsCard.tsx
@@ -241,6 +241,21 @@ export function TagespulsCard({ onCompleteProfile }: TagespulsCardProps) {
           )}
         </blockquote>
 
+        {/*
+          BUG-DAILY-005: deep interpretation EXTENDS, doesn't REPLACE.
+          The consolidated impulse_text stays visible so the user has
+          both layers — general daily framing + archetype-specific
+          deep interpretation.
+        */}
+        {aph.impulse_text && (
+          <p
+            className="text-sm text-ink/80 leading-relaxed"
+            data-testid="tagespuls-impulse-text-phase2"
+          >
+            {aph.impulse_text}
+          </p>
+        )}
+
         <div className="space-y-2">
           <h3 className="text-lg font-medium text-ink">
             {figureLabel}

--- a/src/hooks/useDailyPulse.ts
+++ b/src/hooks/useDailyPulse.ts
@@ -154,6 +154,18 @@ export function useDailyPulse(locale: 'de' | 'en' = 'de'): UseDailyPulseResult {
         }
         setPulse(parsed.data);
         setError(null);
+        // BUG-DAILY-003 + 004: hydrate Phase 2 state from server's
+        // existing_decision so browser-back / refresh / direct URL
+        // load all show the locked Phase 2 immediately — no Phase 1
+        // flash with active selection buttons.
+        if (parsed.data.existing_decision) {
+          const { archetype_key, text } = parsed.data.existing_decision;
+          setSelectedFigure(archetype_key);
+          setInterpretationByKey((prev) => ({
+            ...prev,
+            [archetype_key]: { id: 'hydrated', text },
+          }));
+        }
         setLoading(false);
       } catch (err) {
         if (cancelled) return;

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -508,8 +508,6 @@ const translationsEn: DeepStringRecord = {
   },
   tagespuls: {
     loading: "Loading today...",
-    bridge: "Bridge to today",
-    impulse: "Action impulse",
     council: {
       title: "Who guides you today?",
       sonne: "Sun",
@@ -1036,8 +1034,6 @@ const translationsDe: DeepStringRecord = {
   },
   tagespuls: {
     loading: "Heute wird geladen...",
-    bridge: "Brücke ins Heute",
-    impulse: "Handlungsimpuls",
     council: {
       title: "Wer begleitet dich heute?",
       sonne: "Sonne",

--- a/src/lib/schemas/daily-pulse.ts
+++ b/src/lib/schemas/daily-pulse.ts
@@ -51,6 +51,16 @@ export const PulseWireAphorismSchema = z.object({
 });
 export type PulseWireAphorism = z.infer<typeof PulseWireAphorismSchema>;
 
+// BUG-DAILY-003 + 004: server includes the user's locked decision for
+// today (if any) so the client can hydrate Phase 2 directly on mount,
+// preventing browser-back / refresh from showing a stale Phase 1 with
+// active selection buttons.
+export const ExistingDecisionSchema = z.object({
+  archetype_key: CouncilKeySchema,
+  text: z.string().min(1),
+});
+export type ExistingDecision = z.infer<typeof ExistingDecisionSchema>;
+
 export const DailyPulseResponseSchema = z.object({
   id: z.string(),
   user_id: z.string(),
@@ -62,6 +72,10 @@ export const DailyPulseResponseSchema = z.object({
   aphorism: PulseWireAphorismSchema,
   council: z.array(CouncilFigureSchema).length(6),
   weather_stale: z.boolean(),
+  // BUG-DAILY-003 + 004: source of truth for "user already picked today".
+  // Cross-locale scoped (per the I-3 fix from PR #336) so locale switches
+  // can't bypass the lock. Single roundtrip — no separate /check-decision.
+  existing_decision: ExistingDecisionSchema.nullable(),
 });
 export type DailyPulseResponse = z.infer<typeof DailyPulseResponseSchema>;
 

--- a/src/lib/schemas/daily-pulse.ts
+++ b/src/lib/schemas/daily-pulse.ts
@@ -40,6 +40,12 @@ export const PulseWireAphorismSchema = z.object({
   author: z.string().nullable(),
   attribution_status: AttributionStatusSchema.nullable(),
   slot_1: z.string(),
+  // BUG-DAILY-001: consolidated impulse text. Server combines legacy
+  // slot_2 + slot_3 rows into this field at read time. New rows write
+  // only impulse_text (mirrored to slot_2 in DB for column reuse).
+  // Component prefers impulse_text; slot_2 / slot_3 stay in the schema
+  // for back-compat with cached rows during the transition.
+  impulse_text: z.string().nullable(),
   slot_2: z.string().nullable(),
   slot_3: z.string().nullable(),
 });


### PR DESCRIPTION
## Summary

Closes 5 user-reported bugs on the Tagesimpuls feature. Architectural shift: 3-slot prompt → single consolidated impulse_text; mount-time decision hydration; Phase 2 extends instead of replaces.

| Commit | Bugs | Hash |
|---|---|---|
| 1. \`fix(tagespuls): consolidate slot_2 + slot_3 into impulse_text, drop labels\` | BUG-DAILY-001, 002 | \`6ccf646\` |
| 2. \`fix(tagespuls): hydrate Phase 2 from existing_decision on mount\` | BUG-DAILY-003, 004 | \`f810862\` |
| 3. \`fix(tagespuls): Phase 2 keeps impulse_text visible above interpretation\` | BUG-DAILY-005 | \`09c5a2a\` |
| 4. \`docs(plans): tagespuls bug-daily-001-005 implementation plan\` | trail of intent | \`368eac7\` |

## Highlights

### BUG-001 + BUG-002 — Single consolidated text, no labels
"Bridge to today" / "Action impulse" were INTERNAL prompt labels leaking into UI. LLM now produces ONE woven paragraph; component renders single \`<p>\` with no headers. Wire shape: new \`aphorism.impulse_text\` field; legacy \`slot_2\`/\`slot_3\` stay for cached-row back-compat. DB column reuse — no migration. Side fix discovered during execution: L1 cache + cooldown ledger gates updated from \`if (slot2 && slot3)\` to \`if (slot2)\` since slot_3 is now always null.

### BUG-003 + BUG-004 — Persistent lock on mount
\`/api/daily-pulse\` now includes \`existing_decision: { archetype_key, text } | null\`. Hook hydrates Phase 2 state IMMEDIATELY on mount when present — no Phase 1 flash, no chance to "pick again" via browser back. No localStorage; server is source of truth (already enforced by \`daily_interpretations_one_per_pulse\` UNIQUE).

### BUG-005 — Phase 2 extends, doesn't replace
Deep interpretation now keeps the consolidated \`impulse_text\` visible above the figure-specific interpretation. Both layers always shown.

## Test plan

- [ ] \`npm test\` — 2360/2363 (3 pre-existing flakes verified unrelated: vibes-perf, EDF-NCP-003, api-daily-pulse idempotent)
- [ ] \`npx tsc --noEmit\` — clean
- [ ] \`npm run build\` — OK in 10.35s
- [ ] \`npm run check:text-integrity\` — pass (2755 tracked files; \`tagespuls.bridge\` + \`tagespuls.impulse\` keys removed from DE+EN)
- [ ] Manual smoke after Railway redeploy:
  - Land on dashboard fresh: see impulse_text as ONE paragraph (no "Brücke ins Heute" / "Handlungsimpuls" headers)
  - Pick a figure: deep interpretation appears BELOW the impulse_text (not replacing it)
  - Browser back: stays on Phase 2 with locked decision (no Phase 1 with active buttons)
  - Refresh: Phase 2 renders immediately from server hydration, no flicker

## Test deltas

| Suite | Before | After | New tests |
|---|---|---|---|
| \`tagespuls-card.test.tsx\` | 12 | 16 | TPC-NO-LABELS-001/002, TPC-PHASE2-IMPULSE-001/002 |
| \`use-daily-pulse.test.ts\` | 11 | 13 | DPH-LOCK-MOUNT-001/002 |
| \`daily-pulse.test.mjs\` | 6 | 6 | unchanged |
| \`api-daily-pulse.test.ts\` | 11 | 11 (1 pre-existing fail) | helper rewritten |

## Out of scope (deliberate)

- DB migration to dedicated \`impulse_text\` column. Column reuse on \`slot_2\` is sufficient. A migration that drops \`slot_3\` and renames \`slot_2\` is a future hygiene task.
- 06:00-local-time daily rollover (BUG-DAILY-004 AC #6). System uses UTC date; timezone-aware rollover needs a separate spec discussion.
- "Explore" feature (BUG-DAILY-002 AC #4). No "Explore" UI exists today; persistent text + stable Phase 2 enable the future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)