### PR TITLE
fix(tagespuls): migration idempotency hardening (PR-342 follow-up)

### DIFF
--- a/supabase-migrations/20260510_daily_interpretation_one_per_pulse.sql
+++ b/supabase-migrations/20260510_daily_interpretation_one_per_pulse.sql
@@ -46,5 +46,18 @@ WHERE daily_interpretation.id = ranked_interpretations.id
   AND ranked_interpretations.decision_rank > 1;
 
 -- Add the new constraint: at most one interpretation per daily_pulse_id.
-ALTER TABLE daily_interpretations
-  ADD CONSTRAINT daily_interpretations_one_per_pulse UNIQUE (daily_pulse_id);
+-- Wrapped in IF NOT EXISTS so a migration replay (CI, fresh clone, disaster
+-- recovery) does not fail with 42710 (duplicate_object) after this migration
+-- has already been applied in production.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'daily_interpretations'::regclass
+      AND conname = 'daily_interpretations_one_per_pulse'
+  ) THEN
+    ALTER TABLE daily_interpretations
+      ADD CONSTRAINT daily_interpretations_one_per_pulse UNIQUE (daily_pulse_id);
+  END IF;
+END $$;

--- a/supabase-migrations/20260510_daily_interpretation_one_per_user_date.sql
+++ b/supabase-migrations/20260510_daily_interpretation_one_per_user_date.sql
@@ -35,6 +35,17 @@ CREATE TRIGGER trg_daily_interpretations_scope
   FOR EACH ROW
   EXECUTE FUNCTION set_daily_interpretation_scope();
 
+-- Defensive: remove any orphan interpretations whose daily_pulse_id no
+-- longer matches a daily_pulses row. The FK has ON DELETE CASCADE so
+-- this should never match — but if a manual SQL op or a historic
+-- FK-bypass left a stray row, the backfill below would leave its
+-- user_id/pulse_date NULL and the SET NOT NULL at the end of this
+-- migration would abort. One DELETE removes the foot-gun.
+DELETE FROM daily_interpretations di
+WHERE NOT EXISTS (
+  SELECT 1 FROM daily_pulses dp WHERE dp.id = di.daily_pulse_id
+);
+
 UPDATE daily_interpretations di
 SET user_id = dp.user_id,
     pulse_date = dp.date


### PR DESCRIPTION
## Summary

Follow-up to PR #342 addressing two **Important** findings from the 2026-05-13 post-merge code review. Both are defense-in-depth hygiene fixes — no schema end-state change, only the path to get there.

- **I-1** (`0583143`): `_one_per_pulse.sql` `ADD CONSTRAINT` now wrapped in `DO $$ IF NOT EXISTS` block. Brings it in line with the sibling `_one_per_user_date.sql` pattern. A migration replay (CI, fresh clone, disaster recovery) no longer fails with `42710 duplicate_object`.
- **I-2** (`e22318c`): `_one_per_user_date.sql` now `DELETE`s orphan interpretations before the `SET NOT NULL` backfill. The FK has `ON DELETE CASCADE` so this should be a no-op in practice — defensive against historical FK-bypass scenarios.

**M-1 (redact persist log)** was dropped after a subagent caught a defect in the original review reasoning: the existing `insErr?.code || insErr?.message` short-circuits to `code` for all realistic Supabase JS errors, so `message` never actually reaches the log. The "leak" was hypothetical to a degree that didn't justify the change.

## Visible impact

None on production behavior. Migrations were applied successfully on 2026-05-10 and the prod schema already matches the end-state declared in `supabase-schema.sql`. This PR only changes how the migration files behave on **replay**.

## Test plan

- [x] Baseline `npx vitest run server/__tests__/daily-interpretation.test.mjs` → 15/15 green before the branch
- [x] No server code changed → suite unchanged
- [x] Static SQL inspection: `_one_per_pulse.sql` line count 51 → 63, `_one_per_user_date.sql` 80 → 91
- [x] Migration ordering preserved: ADD COLUMN → FUNCTION → TRIGGER → orphan DELETE → backfill UPDATE → dedupe CTE → SET NOT NULL → ADD CONSTRAINT
- [ ] Manual `supabase migration up` replay test (optional — only if a local Supabase is running; the SQL patterns are well-known idempotent idioms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen idempotency and data-safety of daily interpretation database migrations without changing the final schema state.

Bug Fixes:
- Wrap the daily_interpretations one-per-pulse unique constraint creation in an IF NOT EXISTS block to allow safe migration replays without duplicate constraint errors.
- Delete any orphan daily_interpretations rows before backfilling user_id and pulse_date to prevent potential NOT NULL constraint failures during migration replays.