### PR TITLE
Feature/aphorism batch aph 0089 0121

### DIFF
--- a/src/__tests__/use-first-run-daily.test.ts
+++ b/src/__tests__/use-first-run-daily.test.ts
@@ -42,19 +42,26 @@ const VALID_DAILY: any = {
 };
 
 /**
- * Seed localStorage with a cached daily under today's local-calendar key.
+ * Seed localStorage with a cached daily under the active 06:00 day-window key.
  * Mirrors the `setCachedDaily()` shape in useFirstRunDaily.ts so the
  * cache-hit branch picks it up on first effect run.
  */
-function seedTodayCache(data: unknown): void {
+function activeDailyWindowKey(): string {
   const now = new Date();
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, '0');
-  const d = String(now.getDate()).padStart(2, '0');
-  const todayKey = `${y}-${m}-${d}`;
+  const windowedDate = new Date(now);
+  if (now.getHours() < 6) {
+    windowedDate.setDate(now.getDate() - 1);
+  }
+  const y = windowedDate.getFullYear();
+  const m = String(windowedDate.getMonth() + 1).padStart(2, '0');
+  const d = String(windowedDate.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function seedTodayCache(data: unknown): void {
   window.localStorage.setItem(
     'daily_horoscope_cache',
-    JSON.stringify({ date: todayKey, data }),
+    JSON.stringify({ date: activeDailyWindowKey(), data }),
   );
 }
 
@@ -99,6 +106,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -271,6 +279,35 @@ describe('useFirstRunDaily — error recovery', () => {
     expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(1);
     expect(result.current.dailyData).not.toBeNull();
     expect(result.current.error).toBeNull();
+  });
+
+  it('FRD-WINDOW-001: cold-start before 06:00 fetches the active day-window date', async () => {
+    // Regression for PR #347 review: when there is no valid cache and the
+    // user opens the dashboard between 00:00 and 05:59, the network request
+    // must use the same 06:00 day-window key that getCachedDaily()/setCachedDaily()
+    // use. Otherwise cold-start users see the next calendar day's horoscope at
+    // midnight while cached users keep the previous window until 06:00.
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 20 });
+    vi.setSystemTime(new Date('2026-05-08T05:30:00'));
+    fetchDailyExperienceMock.mockResolvedValueOnce(VALID_DAILY);
+
+    const useFirstRunDaily = await loadHook();
+    const STABLE_QUIZ: number[] = [];
+    const { result } = renderHook(() =>
+      useFirstRunDaily('user-1', VALID_BIRTH, null, STABLE_QUIZ, 'Taurus'),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dailyData).not.toBeNull();
+    });
+
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(1);
+    // fetchDailyExperience(birthData, soulprintSectors, quizSectors, targetDate, ...)
+    expect(fetchDailyExperienceMock.mock.calls[0][3]).toBe('2026-05-07');
+
+    const cached = JSON.parse(window.localStorage.getItem('daily_horoscope_cache') ?? '{}');
+    expect(cached.date).toBe('2026-05-07');
   });
 
   it('FRD-CACHE-001: cache-hit path sets the ref so same-deps re-renders do not re-fetch', async () => {

--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -205,7 +205,8 @@ export function useFirstRunDaily(
   const runDailyFetch = useCallback(async (opts: { signal?: AbortSignal } = {}) => {
     const now = new Date();
     const currentHour = now.getHours();
-    const isTodayTarget = !customDate || customDate === todayKey();
+    const activeWindowKey = dailyCacheKey();
+    const isTodayTarget = !customDate || customDate === activeWindowKey;
     // Deliberate delivery window: modal auto-open is suppressed outside 06:00–17:59 local time.
     // Rationale: daily content is morning-oriented; late-night auto-open is disruptive.
     // Note: Dashboard.tsx currently does NOT consume `showModal` (Wireframe F3 decision —
@@ -213,7 +214,7 @@ export function useFirstRunDaily(
     // retained so the behaviour can be re-enabled cleanly when/if auto-open is restored.
     // Decision 2026-05-06: keep guard, do not remove (Option B confirmed by Ben).
     const isWithinDeliveryWindow = currentHour >= 6 && currentHour < 18;
-    const targetDate = customDate || todayKey();
+    const targetDate = customDate || activeWindowKey;
 
     // Guard: need userId + birthData; soulprint can be null (synthetic fallback).
     // Also avoid re-fetching the same date — but ONLY when the previous
@@ -277,8 +278,8 @@ export function useFirstRunDaily(
         if (!isCurrent()) return;
 
         // 2. Check localStorage cache — serves BOTH inline display and modal.
-        // Only cache for today's date.
-        const isToday = targetDate === todayKey();
+        // Only cache for the active 06:00 day-window.
+        const isToday = targetDate === activeWindowKey;
         if (isToday) {
           const cached = getCachedDaily();
           if (cached) {
@@ -416,8 +417,8 @@ export function useFirstRunDaily(
   const handleClose = useCallback(() => {
     setShowModal(false);
 
-    // Mark today's date as seen in profiles (fire-and-forget)
-    const today = todayKey();
+    // Mark the active 06:00 day-window as seen in profiles (fire-and-forget).
+    const today = dailyCacheKey();
     supabase
       .from('profiles')
       .update({ daily_modal_seen_date: today })


### PR DESCRIPTION
## Summary by Sourcery

Align daily horoscope fetching and caching with a 06:00-based day window and add coverage for pre-06:00 cold starts.

Bug Fixes:
- Ensure cold-start daily fetches before 06:00 use the same 06:00 day-window date as the cache logic to avoid serving the next calendar day's content prematurely.

Enhancements:
- Centralize and reuse the daily 06:00 window cache key for determining target dates, caching behavior, and marking the daily modal as seen.

Tests:
- Extend useFirstRunDaily tests to cover pre-06:00 cold-start behavior and adjust cache seeding to use the 06:00-based day-window key.