### PR TITLE
[Follow-up] Fix apiLimiter skip scope for /space-weather routes

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -327,17 +327,24 @@ app.use('/api/', (req, res, next) => {
 // known high-frequency polling GETs so they don't starve write endpoints.
 const HIGH_FREQ_POLL_PREFIXES = [
   "/transit-state/",
-  "/space-weather",
 ];
+
+const HIGH_FREQ_POLL_PATHS = new Set([
+  "/space-weather",
+]);
+
+const isHighFreqPollRequest = (req) => (
+  HIGH_FREQ_POLL_PREFIXES.some((p) => req.path.startsWith(p)) ||
+  HIGH_FREQ_POLL_PATHS.has(req.path)
+);
+
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 min
   max: 2000,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, please try again later." },
-  skip: (req) =>
-    req.method === "GET" &&
-    HIGH_FREQ_POLL_PREFIXES.some((p) => req.path.startsWith(p)),
+  skip: (req) => req.method === "GET" && isHighFreqPollRequest(req),
 });
 app.use("/api/", apiLimiter);
 


### PR DESCRIPTION
### Motivation
- A `startsWith('/space-weather')` check allowed any `/api/space-weather/*` subroute to bypass the shared `apiLimiter`, widening the skip beyond the intended lightweight poll endpoint. 
- High-frequency user-scoped polling under `/transit-state/` should remain exempt to avoid starving write endpoints. 
- The skip logic should be explicit and easy to extend so future additions don't accidentally widen the exemption.

### Description
- Removed `"/space-weather"` from `HIGH_FREQ_POLL_PREFIXES` and introduced `HIGH_FREQ_POLL_PATHS` as a `Set` containing the exact `"/space-weather"` path. 
- Added `isHighFreqPollRequest(req)` which returns true for matching prefixes or exact paths. 
- Updated the `apiLimiter` `skip` predicate to use `isHighFreqPollRequest(req)` and continue to only skip `GET` requests.

### Testing
- Ran a syntax check with `node --check server.mjs`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f84969b32c83229a20d9f316131e74)

## Summary by Sourcery

Tighten the API rate limiter skip logic for high-frequency polling routes to avoid unintentionally exempting additional /space-weather subpaths.

Enhancements:
- Introduce an explicit helper to detect high-frequency polling requests using a combination of path prefixes and exact paths.
- Restrict the /space-weather rate-limit exemption to the exact path while keeping existing high-frequency polling prefixes intact.