### PR TITLE
fix(useFirstRunDaily): invalidate active fetch before cache guard

### DIFF
--- a/src/__tests__/use-first-run-daily.test.ts
+++ b/src/__tests__/use-first-run-daily.test.ts
@@ -221,6 +221,54 @@ describe('useFirstRunDaily — error recovery', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('FRD-RETRY-005: switching back to an already-fetched key invalidates the active request', async () => {
+    const loadedDaily = { ...VALID_DAILY, meta: { engine_version: 'loaded-de' } };
+    const staleDaily = { ...VALID_DAILY, meta: { engine_version: 'stale-en' } };
+
+    fetchDailyExperienceMock.mockResolvedValueOnce(loadedDaily);
+    let resolveStale!: (value: unknown) => void;
+    fetchDailyExperienceMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStale = resolve;
+      }),
+    );
+
+    const useFirstRunDaily = await loadHook();
+    const STABLE_QUIZ: number[] = [];
+
+    const { result, rerender } = renderHook(
+      ({ locale }: { locale: string }) =>
+        useFirstRunDaily('user-1', VALID_BIRTH, null, STABLE_QUIZ, 'Taurus', undefined, locale),
+      { initialProps: { locale: 'de-DE' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dailyData).toEqual(loadedDaily);
+    });
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(1);
+
+    rerender({ locale: 'en-US' });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+
+    rerender({ locale: 'de-DE' });
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      resolveStale(staleDaily);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dailyData).toEqual(loadedDaily);
+    });
+
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+    expect(result.current.dailyData).not.toEqual(staleDaily);
+    expect(result.current.error).toBeNull();
+  });
+
   it('FRD-RETRY-003: retry() during in-flight request is debounced (no second fetch)', async () => {
     // Use a never-resolving promise so the first fetch stays in flight
     // when retry() is called.

--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -165,21 +165,29 @@ export function useFirstRunDaily(
       locale,
     ].join('::');
 
-    // Avoid re-fetching the same logical daily request — but only when the
-    // previous attempt for these exact inputs succeeded. A same-day change to
-    // locale, birth data, sectors, or sign must not be blocked by a date-only
-    // marker.
-    if (requestKey === lastFetchedRequestKeyRef.current) return;
-
     // 2026-05-15 review fix: if a meaningful dependency changes while a
     // request is in flight, invalidate the older generation and queue exactly
-    // one follow-up fetch for the latest request key. Duplicate retry()/Strict
-    // Mode reruns for the active key are still debounced.
+    // one follow-up fetch for the latest request key BEFORE consulting the
+    // success marker below. Otherwise switching back to an already-fetched key
+    // could return early and let the now-stale in-flight response win.
+    // Duplicate retry()/Strict Mode reruns for the active key are still
+    // debounced.
     if (inFlightRef.current) {
       if (requestKey !== activeRequestKeyRef.current) {
         queuedRequestKeyRef.current = requestKey;
         fetchGenRef.current += 1;
       }
+      return;
+    }
+
+    // Avoid re-fetching the same logical daily request — but only when the
+    // previous attempt for these exact inputs succeeded. A same-day change to
+    // locale, birth data, sectors, or sign must not be blocked by a date-only
+    // marker. If this guard is reached after a queued follow-up invalidated an
+    // obsolete in-flight request, also clear loading because the current data is
+    // already the latest successful result.
+    if (requestKey === lastFetchedRequestKeyRef.current) {
+      setLoading(false);
       return;
     }
 


### PR DESCRIPTION
### Motivation

- Prevent a stale in-flight fetch from winning when the user switches back to a request key that was already fetched, by making sure in-flight invalidation/queueing runs before the cache-success guard. 

### Description

- Move the in-flight handling (queueing an updated `requestKey` and bumping the generation) ahead of the `lastFetchedRequestKeyRef` early-return so a queued follow-up invalidates an active stale generation first. 
- When the already-fetched guard is reached after a queued follow-up invalidated an obsolete in-flight request, clear `loading` and return to avoid remaining stuck in a loading state. 
- Add regression test `FRD-RETRY-005` that reproduces the reviewer scenario: load `de-DE`, start `en-US` (in-flight), switch back to `de-DE`, and assert the stale `en-US` response is ignored without dispatching an extra fetch.

### Testing

- Ran the focused test file with Vitest: `npm test -- src/__tests__/use-first-run-daily.test.ts` — all tests passed (5/5). 
- Typecheck: `npm run lint` — passed. 
- Production build: `npm run build` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a076f57a1888322ad4929162e198858)

## Summary by Sourcery

Ensure useFirstRunDaily correctly handles switching between locales when requests are in flight so stale responses cannot overwrite up-to-date data.

Bug Fixes:
- Prevent an in-flight stale request from overwriting already-fetched data when switching back to a previously loaded request key in useFirstRunDaily.

Tests:
- Add regression test FRD-RETRY-005 to cover switching locales while a request is in flight and ensure stale responses are ignored.