### PR TITLE
Fix daily 06:00 in-flight cache race

### DIFF
--- a/src/__tests__/use-first-run-daily.test.ts
+++ b/src/__tests__/use-first-run-daily.test.ts
@@ -310,6 +310,65 @@ describe('useFirstRunDaily — error recovery', () => {
     expect(cached.date).toBe('2026-05-07');
   });
 
+  it('FRD-WINDOW-002: resolving a pre-06:00 fetch after rotation does not cache yesterday as today', async () => {
+    // Regression for PR #350 review: a cold request can start before 06:00
+    // with yesterday's day-window key, then resolve after the mounted 06:00
+    // timer has already tried to fetch the new window. The in-flight guard
+    // must not let that stale response populate today's cache or UI.
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 20 });
+    vi.setSystemTime(new Date('2026-05-08T05:59:50'));
+
+    let resolvePreRotation: ((value: typeof VALID_DAILY) => void) | undefined;
+    const preRotationPromise = new Promise<typeof VALID_DAILY>((resolve) => {
+      resolvePreRotation = resolve;
+    });
+    const postRotationDaily = {
+      ...VALID_DAILY,
+      fusion: { harmony_index: 0.8, synthesis: 'new-window daily' },
+    };
+
+    fetchDailyExperienceMock
+      .mockReturnValueOnce(preRotationPromise)
+      .mockResolvedValueOnce(postRotationDaily);
+
+    const useFirstRunDaily = await loadHook();
+    const STABLE_QUIZ: number[] = [];
+    const { result } = renderHook(() =>
+      useFirstRunDaily('user-1', VALID_BIRTH, null, STABLE_QUIZ, 'Taurus'),
+    );
+
+    await waitFor(() => {
+      expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(1);
+    });
+    expect(fetchDailyExperienceMock.mock.calls[0][3]).toBe('2026-05-07');
+
+    // Cross the local 06:00 boundary. The scheduled listener invokes
+    // runDailyFetch(), but the first request is still in-flight, so the hook
+    // records a pending new-window refetch instead of starting it immediately.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      resolvePreRotation!(VALID_DAILY);
+    });
+
+    await waitFor(() => {
+      expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+    });
+    expect(fetchDailyExperienceMock.mock.calls[1][3]).toBe('2026-05-08');
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dailyData).toBe(postRotationDaily);
+    });
+
+    const cached = JSON.parse(window.localStorage.getItem('daily_horoscope_cache') ?? '{}');
+    expect(cached.date).toBe('2026-05-08');
+    expect(cached.data).toEqual(postRotationDaily);
+  });
+
   it('FRD-CACHE-001: cache-hit path sets the ref so same-deps re-renders do not re-fetch', async () => {
     // I-3 from the 2026-05-11 PR #343 review: the cache-hit branch in
     // useFirstRunDaily.ts (line 188-196) sets lastFetchedDateRef to

--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -133,11 +133,11 @@ export function getCachedDaily(): DailyResponse | null {
  * Production code should consume the cache via the `useFirstRunDaily`
  * hook — not via direct calls.
  */
-export function setCachedDaily(data: DailyResponse): void {
+export function setCachedDaily(data: DailyResponse, cacheKey = dailyCacheKey()): void {
   try {
     localStorage.setItem(
       'daily_horoscope_cache',
-      JSON.stringify({ date: dailyCacheKey(), data }),
+      JSON.stringify({ date: cacheKey, data }),
     );
   } catch {
     // localStorage full or unavailable — ignore
@@ -179,6 +179,12 @@ export function useFirstRunDaily(
   // fetches. Cleared in the finally branch so the next legitimate
   // trigger works.
   const inFlightRef = useRef<boolean>(false);
+  // If the 06:00 rotation fires while a pre-rotation request is still
+  // in-flight, remember that the skipped invocation must be replayed as
+  // soon as the old request settles. Otherwise the stale response can win
+  // the race and keep yesterday's day-window on screen.
+  const pendingWindowRefetchRef = useRef<boolean>(false);
+  const inFlightWindowKeyRef = useRef<string | null>(null);
   // 2026-05-11 audit fix: per-fetch generation counter. Replaces the
   // local `cancelled` closure flag because that flag was getting set
   // spuriously by R2 effect re-runs (unstable deps + inline `[]`
@@ -228,8 +234,14 @@ export function useFirstRunDaily(
     // and a user mashing retry() during the first fetch fires more.
     // Also defeats unstable-deps races where consumer passes inline `[]`
     // arrays that re-trigger the effect on every render.
-    if (inFlightRef.current) return;
+    if (inFlightRef.current) {
+      if (!customDate && activeWindowKey !== inFlightWindowKeyRef.current) {
+        pendingWindowRefetchRef.current = true;
+      }
+      return;
+    }
     inFlightRef.current = true;
+    inFlightWindowKeyRef.current = activeWindowKey;
 
     // 2026-05-11 audit fix: capture our generation. State updates and
     // the loading toggle only fire if our generation is still current,
@@ -316,7 +328,13 @@ export function useFirstRunDaily(
 
         if (!isCurrent()) return;
 
-        if (isToday) setCachedDaily(data);
+        const completionWindowKey = dailyCacheKey();
+        if (!customDate && targetDate !== completionWindowKey) {
+          pendingWindowRefetchRef.current = true;
+          return;
+        }
+
+        if (isToday) setCachedDaily(data, activeWindowKey);
         setDailyData(data);
         setError(null);
         lastFetchedDateRef.current = targetDate;
@@ -340,6 +358,15 @@ export function useFirstRunDaily(
       } finally {
         if (isCurrent()) setLoading(false);
         inFlightRef.current = false;
+        inFlightWindowKeyRef.current = null;
+
+        if (isCurrent() && pendingWindowRefetchRef.current && !customDate) {
+          pendingWindowRefetchRef.current = false;
+          lastFetchedDateRef.current = null;
+          localStorage.removeItem('daily_horoscope_cache');
+          setDailyData(null);
+          setRetryTick((t) => t + 1);
+        }
       }
     })();
     // Note: quizSectors and soulprintSectors are NOT in the dep array


### PR DESCRIPTION
### Motivation
- Prevent a race where a cold fetch started before the 06:00 day-window boundary can be stored under the new day's cache key if it resolves after rotation.
- Ensure the hook does not permanently serve stale (previous-window) content when the 06:00 timer fires while a request is in-flight.

### Description
- Change `setCachedDaily` to accept an optional `cacheKey` and tag cache writes with the fetch's captured window key instead of recomputing it at write time. (file: `src/hooks/useFirstRunDaily.ts`)
- Track the in-flight window via `inFlightWindowKeyRef` and enqueue a pending refetch with `pendingWindowRefetchRef` when the 06:00 rotation occurs while an earlier-window request is in-flight. (file: `src/hooks/useFirstRunDaily.ts`)
- Discard responses whose target day-window no longer matches the current 06:00 window, clear stale cache/state, and trigger a follow-up fetch for the new window. (file: `src/hooks/useFirstRunDaily.ts`)
- Add a regression test `FRD-WINDOW-002` that simulates a pre-06:00 request resolving after 06:00 and asserts the hook fetches and caches the new window instead of persisting yesterday as today. (file: `src/__tests__/use-first-run-daily.test.ts`)

### Testing
- Ran the hook unit tests with `npx vitest run src/__tests__/use-first-run-daily.test.ts` and the suite passed (`8 passed`).
- Ran the six-am cache-rotation and refetch tests with supabase env set: `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=test npx vitest run src/__tests__/daily-pulse-six-am-cache-rotation.test.ts src/__tests__/dashboard-daily-pulse-six-am-refetch.test.tsx` and they passed.
- Type-check/lint via `npm run lint` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a076f5b68fc8322a9f8dbd74b6f1461)

## Summary by Sourcery

Fix race conditions around the 06:00 daily window rotation in the first-run daily hook to avoid caching or displaying stale data when in-flight requests span the boundary.

Bug Fixes:
- Ensure pre-06:00 in-flight daily fetches resolving after the 06:00 rotation do not populate the new day’s cache or UI with stale data.
- Prevent skipped 06:00 rotations from leaving the hook permanently serving the previous day’s content when a request is in-flight.

Enhancements:
- Track in-flight daily fetch window keys and pending window refetches to replay a missed 06:00 fetch once the current request settles.
- Tag daily cache writes with the fetch’s captured window key instead of recomputing the key at write time to keep storage aligned with the intended day-window.

Tests:
- Add regression test FRD-WINDOW-002 to cover in-flight pre-rotation fetches resolving after 06:00 and verify correct refetching and caching for the new window.