### PR TITLE
fix(useFirstRunDaily): invalidate active fetch before cache guard

### DIFF
--- a/src/__tests__/use-first-run-daily.test.ts
+++ b/src/__tests__/use-first-run-daily.test.ts
@@ -221,6 +221,54 @@ describe('useFirstRunDaily — error recovery', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('FRD-RETRY-005: switching back to an already-fetched key invalidates the active request', async () => {
+    const loadedDaily = { ...VALID_DAILY, meta: { engine_version: 'loaded-de' } };
+    const staleDaily = { ...VALID_DAILY, meta: { engine_version: 'stale-en' } };
+
+    fetchDailyExperienceMock.mockResolvedValueOnce(loadedDaily);
+    let resolveStale!: (value: unknown) => void;
+    fetchDailyExperienceMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStale = resolve;
+      }),
+    );
+
+    const useFirstRunDaily = await loadHook();
+    const STABLE_QUIZ: number[] = [];
+
+    const { result, rerender } = renderHook(
+      ({ locale }: { locale: string }) =>
+        useFirstRunDaily('user-1', VALID_BIRTH, null, STABLE_QUIZ, 'Taurus', undefined, locale),
+      { initialProps: { locale: 'de-DE' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dailyData).toEqual(loadedDaily);
+    });
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(1);
+
+    rerender({ locale: 'en-US' });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+
+    rerender({ locale: 'de-DE' });
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      resolveStale(staleDaily);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dailyData).toEqual(loadedDaily);
+    });
+
+    expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
+    expect(result.current.dailyData).not.toEqual(staleDaily);
+    expect(result.current.error).toBeNull();
+  });
+
   it('FRD-RETRY-003: retry() during in-flight request is debounced (no second fetch)', async () => {
     // Use a never-resolving promise so the first fetch stays in flight
     // when retry() is called.

--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -165,21 +165,29 @@ export function useFirstRunDaily(
       locale,
     ].join('::');
 
-    // Avoid re-fetching the same logical daily request — but only when the
-    // previous attempt for these exact inputs succeeded. A same-day change to
-    // locale, birth data, sectors, or sign must not be blocked by a date-only
-    // marker.
-    if (requestKey === lastFetchedRequestKeyRef.current) return;
-
     // 2026-05-15 review fix: if a meaningful dependency changes while a
     // request is in flight, invalidate the older generation and queue exactly
-    // one follow-up fetch for the latest request key. Duplicate retry()/Strict
-    // Mode reruns for the active key are still debounced.
+    // one follow-up fetch for the latest request key BEFORE consulting the
+    // success marker below. Otherwise switching back to an already-fetched key
+    // could return early and let the now-stale in-flight response win.
+    // Duplicate retry()/Strict Mode reruns for the active key are still
+    // debounced.
     if (inFlightRef.current) {
       if (requestKey !== activeRequestKeyRef.current) {
         queuedRequestKeyRef.current = requestKey;
         fetchGenRef.current += 1;
       }
+      return;
+    }
+
+    // Avoid re-fetching the same logical daily request — but only when the
+    // previous attempt for these exact inputs succeeded. A same-day change to
+    // locale, birth data, sectors, or sign must not be blocked by a date-only
+    // marker. If this guard is reached after a queued follow-up invalidated an
+    // obsolete in-flight request, also clear loading because the current data is
+    // already the latest successful result.
+    if (requestKey === lastFetchedRequestKeyRef.current) {
+      setLoading(false);
       return;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust useFirstRunDaily request invalidation to prevent stale in-flight responses from overwriting already-fetched results when switching back to a previous key.

Bug Fixes:
- Ensure switching back to an already-fetched daily key invalidates any stale in-flight request so its response cannot overwrite the current data.

Tests:
- Add regression test covering locale switching that triggers invalidation of an active request and confirms stale responses are ignored.