### PR TITLE
Codex/fix high priority bug in usefirstrundaily

### DIFF
--- a/src/__tests__/use-first-run-daily.test.ts
+++ b/src/__tests__/use-first-run-daily.test.ts
@@ -264,6 +264,9 @@ describe('useFirstRunDaily — error recovery', () => {
       expect(result.current.dailyData).toEqual(loadedDaily);
     });
 
+    const cached = JSON.parse(window.localStorage.getItem('daily_horoscope_cache') ?? 'null');
+    expect(cached?.data).toEqual(loadedDaily);
+
     expect(fetchDailyExperienceMock).toHaveBeenCalledTimes(2);
     expect(result.current.dailyData).not.toEqual(staleDaily);
     expect(result.current.error).toBeNull();

--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -173,7 +173,10 @@ export function useFirstRunDaily(
     // Duplicate retry()/Strict Mode reruns for the active key are still
     // debounced.
     if (inFlightRef.current) {
-      if (requestKey !== activeRequestKeyRef.current) {
+      if (
+        requestKey !== activeRequestKeyRef.current &&
+        requestKey !== queuedRequestKeyRef.current
+      ) {
         queuedRequestKeyRef.current = requestKey;
         fetchGenRef.current += 1;
       }
@@ -187,6 +190,7 @@ export function useFirstRunDaily(
     // obsolete in-flight request, also clear loading because the current data is
     // already the latest successful result.
     if (requestKey === lastFetchedRequestKeyRef.current) {
+      queuedRequestKeyRef.current = null;
       setLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary by Sourcery

Fix request queuing logic and cache handling in useFirstRunDaily to prevent stale reloads and ensure correct daily data state.

Bug Fixes:
- Prevent enqueuing duplicate queued requests while an in-flight request is active in useFirstRunDaily.
- Clear any queued follow-up request when handling a response for the last fetched request key to avoid unnecessary refetching.

Tests:
- Extend useFirstRunDaily error recovery tests to assert that the cached daily data in localStorage is updated to the recovered value.