### PR TITLE
Codex/create branch for bazodiac fly fix

### DIFF
--- a/scripts/fly-preflight.mjs
+++ b/scripts/fly-preflight.mjs
@@ -1,12 +1,47 @@
 #!/usr/bin/env node
 
+import { execFileSync } from 'node:child_process';
+
 const requiredVars = ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'];
-const missing = requiredVars.filter((name) => !process.env[name]);
+
+function getFlyAppName() {
+  const appFromEnv = process.env.FLY_APP?.trim();
+  if (appFromEnv) {
+    return appFromEnv;
+  }
+
+  console.error('[fly-preflight] Missing Fly app name. Set FLY_APP before running predeploy checks.');
+  console.error('[fly-preflight] Example: FLY_APP=bazodiac-fly npm run predeploy:fly');
+  process.exit(1);
+}
+
+function listFlySecrets(appName) {
+  try {
+    const raw = execFileSync('flyctl', ['secrets', 'list', '--app', appName, '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return JSON.parse(raw);
+  } catch (error) {
+    const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
+    const details = stderr || error.message;
+    console.error(`[fly-preflight] Could not read Fly secrets for app "${appName}".`);
+    console.error(`[fly-preflight] ${details}`);
+    console.error('[fly-preflight] Ensure flyctl is installed and you are authenticated: fly auth login');
+    process.exit(1);
+  }
+}
+
+const appName = getFlyAppName();
+const secrets = listFlySecrets(appName);
+const secretNames = new Set(secrets.map((secret) => secret.Name));
+const missing = requiredVars.filter((name) => !secretNames.has(name));
 
 if (missing.length > 0) {
-  console.error(`[fly-preflight] Missing required env vars: ${missing.join(', ')}`);
-  console.error('[fly-preflight] Set them in Fly secrets before deploy:');
-  console.error(`  fly secrets set ${missing.map((name) => `${name}=<value>`).join(' ')}`);
+  console.error(`[fly-preflight] Missing required Fly secrets on app "${appName}": ${missing.join(', ')}`);
+  console.error('[fly-preflight] Set them before deploy:');
+  console.error(`  fly secrets set --app ${appName} ${missing.map((name) => `${name}=<value>`).join(' ')}`);
   process.exit(1);
 }
 
@@ -15,4 +50,4 @@ if (port !== '8080') {
   console.warn(`[fly-preflight] PORT is ${port}. Fly health checks usually expect 8080.`);
 }
 
-console.log('[fly-preflight] OK: required runtime env vars are present.');
+console.log(`[fly-preflight] OK: required runtime secrets exist on Fly app "${appName}".`);


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyai2025/astro-noctum/pull/366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Validate Fly deployment configuration by checking required Supabase secrets on the target Fly app before deploy instead of relying on local environment variables.

Enhancements:
- Require FLY_APP to be set and use it to query Fly secrets via flyctl before deployment.
- Improve error and success messages to clearly reference missing or present secrets on the specified Fly app and provide concrete flyctl commands to fix them.