### PR TITLE
fix: serve production Vite bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,54 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <style>
+      .bazodiac-boot-fallback {
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        color: #f7ead2;
+        background: radial-gradient(circle at center, rgba(200, 221, 240, 0.14), transparent 42%), #020509;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        letter-spacing: 0.16em;
+        text-align: center;
+      }
+      .bazodiac-boot-fallback strong {
+        display: block;
+        margin-bottom: 0.75rem;
+        font-size: clamp(1.5rem, 5vw, 3.25rem);
+      }
+      .bazodiac-boot-fallback span {
+        display: block;
+        color: #c8ddf0;
+        font-size: clamp(0.75rem, 2vw, 1rem);
+      }
+      .bazodiac-boot-fallback p {
+        max-width: 34rem;
+        margin: 1.25rem auto 0;
+        color: rgba(247, 234, 210, 0.78);
+        font-size: 0.8rem;
+        letter-spacing: 0.04em;
+        line-height: 1.6;
+      }
+    </style>
+    <div id="root">
+      <div class="bazodiac-boot-fallback" role="status" aria-live="polite">
+        <div>
+          <strong>BAZODIAC</strong>
+          <span>TOUCH THE SURFACE</span>
+        </div>
+      </div>
+    </div>
+    <noscript>
+      <div class="bazodiac-boot-fallback" role="alert">
+        <div>
+          <strong>BAZODIAC</strong>
+          <span>JavaScript is required to open the surface.</span>
+          <p>Please enable JavaScript and reload. If this message stays visible with JavaScript enabled, the production bundle did not load correctly.</p>
+        </div>
+      </div>
+    </noscript>
     <!-- Global Film Grain Overlay (decorative, dark-theme splash) -->
     <div class="grain-overlay" style="pointer-events:none;position:fixed;inset:0;z-index:200;opacity:0.03"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "typecheck": "node ./scripts/run-typecheck.mjs",
     "check:runtime-imports": "node scripts/check-runtime-ts-imports.mjs",
     "seed:aphorisms": "node --env-file=.env scripts/seed-aphorisms.mjs",
-    "predeploy:fly": "node scripts/fly-preflight.mjs"
+    "predeploy:fly": "node scripts/fly-preflight.mjs",
+    "smoke:production-html": "node scripts/smoke-production-html.mjs"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/scripts/smoke-production-html.mjs
+++ b/scripts/smoke-production-html.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const urlArgIndex = args.findIndex((arg) => arg === "--url" || arg === "-u");
+const explicitUrl = urlArgIndex >= 0 ? args[urlArgIndex + 1] : null;
+const baseUrl = explicitUrl || process.env.SMOKE_URL || process.env.PRODUCTION_URL || null;
+
+const hasDevEntrypoint = (html) => /\/src\/main\.tsx(?:["'?]|$)/.test(html);
+const hasBuiltScript = (html) => /<script\b[^>]+src=["']\/assets\/[^"']+\.js[^"']*["'][^>]*>/i.test(html);
+const hasBuiltStylesheet = (html) => /<link\b[^>]+rel=["']stylesheet["'][^>]+href=["']\/assets\/[^"']+\.css[^"']*["'][^>]*>/i.test(html);
+
+function assertProductionHtml(html, label) {
+  const checks = [
+    [!hasDevEntrypoint(html), "must not reference /src/main.tsx"],
+    [hasBuiltScript(html), "must reference generated /assets/*.js"],
+    [hasBuiltStylesheet(html), "must reference generated /assets/*.css"],
+  ];
+  const failures = checks.filter(([ok]) => !ok).map(([, message]) => message);
+
+  if (failures.length > 0) {
+    throw new Error(`${label} is not production Vite HTML:\n- ${failures.join("\n- ")}`);
+  }
+}
+
+async function readLocalDistHtml() {
+  const distIndex = path.resolve("dist", "index.html");
+  const html = await fs.readFile(distIndex, "utf8");
+  assertProductionHtml(html, distIndex);
+  console.log(`[smoke] ${distIndex} references built Vite assets and no /src/main.tsx entrypoint.`);
+}
+
+async function fetchHtml(url) {
+  const response = await fetch(url, { redirect: "follow" });
+  const html = await response.text();
+  const contentType = response.headers.get("content-type") || "";
+
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  if (!contentType.toLowerCase().includes("text/html")) {
+    throw new Error(`${url} returned non-HTML content-type: ${contentType || "<missing>"}`);
+  }
+
+  return html;
+}
+
+async function fetchProductionHtml() {
+  const rootUrl = new URL("/", baseUrl).toString();
+  const nestedUrl = new URL("/dashboard", baseUrl).toString();
+  const rootHtml = await fetchHtml(rootUrl);
+  const nestedHtml = await fetchHtml(nestedUrl);
+
+  assertProductionHtml(rootHtml, rootUrl);
+  assertProductionHtml(nestedHtml, nestedUrl);
+  console.log(`[smoke] ${rootUrl} serves built Vite HTML.`);
+  console.log(`[smoke] ${nestedUrl} returns the SPA index fallback.`);
+}
+
+try {
+  if (baseUrl) {
+    await fetchProductionHtml();
+  } else {
+    await readLocalDistHtml();
+    console.log("[smoke] Set SMOKE_URL=https://bazodiac.space to validate deployed production HTML and /dashboard fallback.");
+  }
+} catch (error) {
+  console.error(`[smoke] ${error.message}`);
+  process.exit(1);
+}

--- a/server.mjs
+++ b/server.mjs
@@ -424,6 +424,40 @@ const dailyInterpretationLimiter = rateLimit({
 });
 
 const distPath = path.join(__dirname, "dist");
+const distIndexPath = path.join(distPath, "index.html");
+
+function validateProductionBundle() {
+  const shouldValidate = process.env.NODE_ENV === "production"
+    || Boolean(process.env.RAILWAY_ENVIRONMENT || process.env.RAILWAY_PUBLIC_DOMAIN || process.env.FLY_APP_NAME);
+  if (!shouldValidate) return;
+
+  if (!fs.existsSync(distIndexPath)) {
+    console.error(
+      `[server] Missing production bundle at ${distIndexPath}. Run "npm run build" before "npm run start".`,
+    );
+    process.exit(1);
+  }
+
+  const html = fs.readFileSync(distIndexPath, "utf8");
+  const hasDevEntrypoint = /\/src\/main\.tsx(?:["'?]|$)/.test(html);
+  const hasBuiltScript = /<script\b[^>]+src=["']\/assets\/[^"']+\.js[^"']*["'][^>]*>/i.test(html);
+  const hasBuiltStylesheet = /<link\b[^>]+rel=["']stylesheet["'][^>]+href=["']\/assets\/[^"']+\.css[^"']*["'][^>]*>/i.test(html);
+
+  if (hasDevEntrypoint || !hasBuiltScript || !hasBuiltStylesheet) {
+    console.error(
+      [
+        "[server] Invalid production bundle: dist/index.html must be Vite build output.",
+        `  contains /src/main.tsx: ${hasDevEntrypoint}`,
+        `  contains /assets/*.js: ${hasBuiltScript}`,
+        `  contains /assets/*.css: ${hasBuiltStylesheet}`,
+        "Run \"npm run build\" during deploy and serve dist/index.html, not the repository root index.html.",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+}
+
+validateProductionBundle();
 
 // BAFE API URLs - build ordered list for fallback chain.
 // Railway private networking (.railway.internal) is IPv6-only and often
@@ -6511,7 +6545,7 @@ app.post("/api/share", requireUserAuth, async (req, res) => {
 
 // Public share page — serve the SPA so client-side handles /share/:hash
 app.get("/share/:hash", async (_req, res) => {
-  const html = await fs.promises.readFile(path.join(distPath, "index.html"), "utf-8");
+  const html = await fs.promises.readFile(distIndexPath, "utf-8");
   res.send(html);
 });
 
@@ -6579,7 +6613,12 @@ app.use(compression({
 app.use("/assets", express.static(path.join(distPath, "assets"), {
   maxAge: "1y",
   immutable: true,
+  fallthrough: false,
 }));
+
+app.get("/src/*", (_req, res) => {
+  res.status(404).type("text/plain").send("Production builds do not serve Vite source files. Serve dist/index.html instead.");
+});
 
 // Other static files (HTML, media, icons) — short cache, revalidate
 app.use(express.static(distPath, {
@@ -6593,7 +6632,7 @@ app.use(express.static(distPath, {
 }));
 
 app.get("/fu-ring", (_req, res) => {
-  const html = fs.readFileSync(path.join(distPath, "index.html"), "utf8");
+  const html = fs.readFileSync(distIndexPath, "utf8");
   const ogHtml = html.replace(
     "<head>",
     `<head>
@@ -6605,7 +6644,7 @@ app.get("/fu-ring", (_req, res) => {
 });
 
 app.get("*", (_req, res) => {
-  res.sendFile(path.join(distPath, "index.html"));
+  res.sendFile(distIndexPath);
 });
 
 // ── POST /api/analyze/conversation — Dialogue analysis with Gemini ──────


### PR DESCRIPTION
### Motivation
- Prevent production from serving the repository root `index.html` (dev entrypoint) and eliminate the black screen caused by a served `/src/main.tsx` module in prod.
- Ensure the Express server serves the built Vite `dist/` assets and returns the SPA `index.html` for nested routes so reloads like `/dashboard` return the app instead of 404.
- Make the production failure mode diagnosable by adding a visible no-JS / boot fallback and a smoke test that detects dev entrypoints in served HTML.

### Description
- Added `validateProductionBundle()` to `server.mjs` that fails fast in production when `dist/index.html` is missing, references `/src/main.tsx`, or lacks generated `/assets/*.js` and `/assets/*.css` references, and replaced inline `path.join(distPath, "index.html")` uses with a shared `distIndexPath`.
- Hardened static serving in `server.mjs` by adding `fallthrough: false` for `/assets`, returning `404` for `/src/*` requests, and ensuring SPA fallback `app.get('*')` serves the built `dist/index.html`.
- Added a visible boot/no-JS fallback to `index.html` showing "BAZODIAC / TOUCH THE SURFACE" and a helpful noscript diagnostic so users do not see a pure black screen when the bundle fails to load.
- Introduced `scripts/smoke-production-html.mjs` plus `npm run smoke:production-html` to validate a local `dist/index.html` or a deployed URL (root + `/dashboard`) for the presence/absence of `/src/main.tsx` and presence of `/assets/*.js` and `/assets/*.css`.

### Testing
- `npm run build` — passed and produced `dist/index.html` with `/assets/*.js` and `/assets/*.css` references.
- `npm run smoke:production-html` — passed locally against the generated `dist/index.html` (no `/src/main.tsx` and built assets present).
- `node --check server.mjs` and starting the server in production mode (`PORT=4179 NODE_ENV=production ... npm run start`) — succeeded and the running server served the built index; local curl checks confirmed `/` and `/dashboard` return the same SPA index and `/src/main.tsx` returns `404 text/plain`.
- `npm run lint` — failed due to unrelated existing TypeScript errors in `src/hooks/useFirstRunDaily.ts` (not caused by this change).
- Remote validation against `https://bazodiac.space` via `SMOKE_URL` / `curl` could not be completed from this environment due to network/proxy restrictions (403 CONNECT tunnel / fetch failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a214a985bbc8322b200db7c77269de1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyai2025/astro-noctum/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->