### PR TITLE
Align run ledger `resume-point` to canonical mandatory gate contract

### DIFF
--- a/plumbline_run_ledger.py
+++ b/plumbline_run_ledger.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Plumbline run ledger helpers.
+
+The ledger is an append-only CSV of gate status rows. ``resume-point`` evaluates
+progress against the mandatory canonical gate sequence below, not against the
+order in which gates first appeared in a ledger. The command returns the first
+canonical gate whose latest ledger row is missing or whose latest status is not
+``CLEARED``.
+
+The command intentionally fails closed: missing, empty, unreadable, or malformed
+ledgers are treated as having no cleared gates, so the resume point is the first
+canonical gate. An explicit ``__RUN_COMPLETE__`` row with status ``CLEARED`` is
+preserved as an override and reports the run as complete.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable
+
+CLEARED = "CLEARED"
+RUN_COMPLETE_GATE = "__RUN_COMPLETE__"
+
+# Mandatory gates are evaluated in this contract order. Keep this list explicit
+# so resume decisions cannot drift with arbitrary first-seen ledger row order.
+CANONICAL_MANDATORY_GATES: tuple[str, ...] = (
+    "phase0",
+    "phase0_5_spec_sanity",
+    "gateA_verification",
+)
+
+GATE_FIELD_CANDIDATES = ("gate", "gate_id", "name", "id")
+STATUS_FIELD_CANDIDATES = ("status", "state", "result")
+
+
+def _first_present(row: dict[str, str], names: Iterable[str]) -> str | None:
+    for name in names:
+        value = row.get(name)
+        if value is not None and value.strip():
+            return value.strip()
+    return None
+
+
+def _latest_statuses_from_dict_rows(rows: Iterable[dict[str, str]]) -> dict[str, str] | None:
+    latest: dict[str, str] = {}
+    for row in rows:
+        gate = _first_present(row, GATE_FIELD_CANDIDATES)
+        status = _first_present(row, STATUS_FIELD_CANDIDATES)
+        if gate is None or status is None:
+            return None
+        latest[gate] = status
+    return latest
+
+
+def _latest_statuses_from_positional_rows(rows: Iterable[list[str]]) -> dict[str, str] | None:
+    latest: dict[str, str] = {}
+    for row in rows:
+        fields = [field.strip() for field in row]
+        if len(fields) < 2 or not fields[0] or not fields[1]:
+            return None
+        latest[fields[0]] = fields[1]
+    return latest
+
+
+def read_latest_statuses(ledger_path: Path) -> dict[str, str]:
+    """Return the latest status per gate, or an empty map on fail-closed input."""
+
+    try:
+        content = ledger_path.read_text(encoding="utf-8", newline="")
+    except OSError:
+        return {}
+
+    if not content.strip():
+        return {}
+
+    try:
+        sample = content[:2048]
+        has_header = csv.Sniffer().has_header(sample)
+    except csv.Error:
+        has_header = False
+
+    try:
+        if has_header:
+            reader = csv.DictReader(content.splitlines())
+            if not reader.fieldnames:
+                return {}
+            lowered = {field.strip().lower(): field for field in reader.fieldnames if field}
+            if not any(name in lowered for name in GATE_FIELD_CANDIDATES):
+                return {}
+            if not any(name in lowered for name in STATUS_FIELD_CANDIDATES):
+                return {}
+            normalized_rows = (
+                {key.strip().lower(): value for key, value in row.items() if key is not None}
+                for row in reader
+            )
+            latest = _latest_statuses_from_dict_rows(normalized_rows)
+        else:
+            latest = _latest_statuses_from_positional_rows(csv.reader(content.splitlines()))
+    except (csv.Error, UnicodeError):
+        return {}
+
+    return latest or {}
+
+
+def resume_point(latest_statuses: dict[str, str]) -> str:
+    """Return the next canonical gate to run, or ``__RUN_COMPLETE__``."""
+
+    if latest_statuses.get(RUN_COMPLETE_GATE) == CLEARED:
+        return RUN_COMPLETE_GATE
+
+    for gate in CANONICAL_MANDATORY_GATES:
+        if latest_statuses.get(gate) != CLEARED:
+            return gate
+
+    return RUN_COMPLETE_GATE
+
+
+def cmd_resume_point(args: argparse.Namespace) -> int:
+    print(resume_point(read_latest_statuses(Path(args.ledger))))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect a Plumbline run ledger.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resume_parser = subparsers.add_parser(
+        "resume-point",
+        help="print the first missing or non-CLEARED mandatory canonical gate",
+    )
+    resume_parser.add_argument("ledger", help="path to the run ledger CSV")
+    resume_parser.set_defaults(func=cmd_resume_point)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plumbline_run_ledger.py
+++ b/plumbline_run_ledger.py
@@ -92,7 +92,11 @@ def read_latest_statuses(ledger_path: Path) -> dict[str, str]:
             if not any(name in lowered for name in STATUS_FIELD_CANDIDATES):
                 return {}
             normalized_rows = (
-                {key.strip().lower(): value for key, value in row.items() if key is not None}
+                {
+                    key.strip().lower(): (value or "")
+                    for key, value in row.items()
+                    if key is not None
+                }
                 for row in reader
             )
             latest = _latest_statuses_from_dict_rows(normalized_rows)

--- a/plumbline_run_ledger.py
+++ b/plumbline_run_ledger.py
@@ -68,8 +68,8 @@ def read_latest_statuses(ledger_path: Path) -> dict[str, str]:
     """Return the latest status per gate, or an empty map on fail-closed input."""
 
     try:
-        content = ledger_path.read_text(encoding="utf-8", newline="")
-    except OSError:
+        content = ledger_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
         return {}
 
     if not content.strip():

--- a/tests/test_run_ledger.sh
+++ b/tests/test_run_ledger.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verifies that resume-point follows the mandatory canonical gate contract.
+# It must not choose gates by first-seen ledger row order.
+
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+LEDGER_TOOL="$ROOT_DIR/plumbline_run_ledger.py"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/plumbline-ledger.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_resume_point() {
+  local ledger_path="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(python3 "$LEDGER_TOOL" resume-point "$ledger_path")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'expected resume point %s, got %s\n' "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+# Missing/empty/corrupt ledgers fail closed to the first canonical gate.
+assert_resume_point "$TMP_DIR/missing.csv" "phase0"
+: > "$TMP_DIR/empty.csv"
+assert_resume_point "$TMP_DIR/empty.csv" "phase0"
+printf 'timestamp,gate\n2026-06-04T00:00:00Z,phase0\n' > "$TMP_DIR/corrupt.csv"
+assert_resume_point "$TMP_DIR/corrupt.csv" "phase0"
+
+# Contract drift guard: a non-canonical row recorded before an absent canonical
+# gate must not become the resume point.
+cat > "$TMP_DIR/drift.csv" <<'CSV'
+timestamp,gate,status
+2026-06-04T00:00:00Z,phase0,CLEARED
+2026-06-04T00:01:00Z,gateA_verification,PENDING
+CSV
+assert_resume_point "$TMP_DIR/drift.csv" "phase0_5_spec_sanity"
+
+# Latest row wins per gate while canonical order chooses the resume point.
+cat > "$TMP_DIR/latest.csv" <<'CSV'
+timestamp,gate,status
+2026-06-04T00:00:00Z,phase0,PENDING
+2026-06-04T00:01:00Z,phase0,CLEARED
+2026-06-04T00:02:00Z,phase0_5_spec_sanity,PENDING
+CSV
+assert_resume_point "$TMP_DIR/latest.csv" "phase0_5_spec_sanity"
+
+# Explicit completion sentinel remains authoritative.
+cat > "$TMP_DIR/complete.csv" <<'CSV'
+timestamp,gate,status
+2026-06-04T00:00:00Z,__RUN_COMPLETE__,CLEARED
+CSV
+assert_resume_point "$TMP_DIR/complete.csv" "__RUN_COMPLETE__"
+
+printf 'test_run_ledger.sh: ok\n'


### PR DESCRIPTION
### Motivation

- The `resume-point` behavior must follow an explicit mandatory canonical gate sequence rather than the order gates first appear in a ledger to avoid contract drift. 
- Missing/empty/corrupt ledgers must continue to fail-closed and an explicit `__RUN_COMPLETE__` sentinel must remain authoritative.

### Description

- Add `plumbline_run_ledger.py` which introduces `CANONICAL_MANDATORY_GATES` and evaluates resume points by iterating that canonical list. 
- Implement safe CSV parsing in `read_latest_statuses()` that returns an empty map on missing/empty/unreadable/malformed input (fail-closed) and returns latest-per-gate from either headered or positional CSVs. 
- Implement `resume_point()` to return the first canonical gate whose latest status is missing or not `CLEARED`, while preserving `__RUN_COMPLETE__` with `CLEARED` as an override. 
- Add `tests/test_run_ledger.sh` and update the module docstring and test header text to describe canonical-gate evaluation instead of recorded/first-seen order. 

### Testing

- Ran `python3 -m py_compile plumbline_run_ledger.py` which succeeded. 
- Ran the portable regression test `tests/test_run_ledger.sh` and `bash -n tests/test_run_ledger.sh`, both of which succeeded and printed the expected results. 
- Ran `npm run check:text-integrity` which passed for tracked files. 
- Ran `VITE_SUPABASE_URL=... VITE_SUPABASE_ANON_KEY=... npm run build` with placeholder env which completed successfully. 
- Ran `npm run typecheck` which failed due to pre-existing TypeScript errors in `src/hooks/useFirstRunDaily.ts` unrelated to these ledger changes. 
- Ran `npm test` which showed unrelated app test failures (missing Supabase env, local API connectivity and existing `useFirstRunDaily` test failures) and did not indicate any regression from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21f5cc44188322b96cf7e97d19b69b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyai2025/astro-noctum/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->