### PR TITLE
fix(build): declare VITE_* build args (dead-frontend root cause)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,18 @@ RUN npm ci --include=dev
 # Copy application code
 COPY . .
 
+# Vite bakes VITE_* vars into the bundle at BUILD time. Railway passes service
+# variables as build args, but Docker only sees them when declared as ARG here.
+# Without these the frontend crashes at init ("Missing VITE_SUPABASE_URL...").
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+ARG VITE_SUPABASE_PUBLISHABLE_API_KEY
+ARG VITE_BAFE_BASE_URL
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL \
+    VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY \
+    VITE_SUPABASE_PUBLISHABLE_API_KEY=$VITE_SUPABASE_PUBLISHABLE_API_KEY \
+    VITE_BAFE_BASE_URL=$VITE_BAFE_BASE_URL
+
 # Build application
 RUN npm run build
 


### PR DESCRIPTION
Frontend on bazodiac.space crashed at module init: bundle built without VITE_SUPabase vars because the Dockerfile (Fly-generated) declares no ARGs — Railway passes service vars as build args only when declared. Browser-verified root cause: `Uncaught Error: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY @assets/index-BJO_VV5W.js:34`. All four VITE vars already exist on the Railway service; this just lets the build see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyai2025/astro-noctum/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->