### PR TITLE
fix(useFirstRunDaily): repair bad-merge regressions failing CI Type Check

### DIFF
--- a/src/hooks/useFirstRunDaily.ts
+++ b/src/hooks/useFirstRunDaily.ts
@@ -107,17 +107,26 @@ export function dailyCacheKey(): string {
  * testing in `src/__tests__/daily-pulse-six-am-cache-rotation.test.ts`.
  * Production code should consume the cache via the `useFirstRunDaily`
  * hook — not via direct calls — to preserve the hook's invariants
- * (dedupe via `lastFetchedDateRef`, error-state propagation, etc.).
+ * (dedupe via `lastFetchedRequestKeyRef`, error-state propagation, etc.).
  */
-export function getCachedDaily(): DailyResponse | null {
+export function getCachedDaily(requestKey?: string): DailyResponse | null {
   try {
     const raw = localStorage.getItem('daily_horoscope_cache');
     if (!raw) return null;
     const parsed = JSON.parse(raw);
-    if (parsed?.date === dailyCacheKey() && parsed?.data) {
-      return parsed.data as DailyResponse;
+    if (parsed?.date !== dailyCacheKey() || !parsed?.data) return null;
+    // Same-day changes to the logical request (locale, birth data, sectors,
+    // sign) must not be served from a cache written for different inputs.
+    // Entries written before `requestKey` existed — or seeded without one —
+    // match any caller, so the day-window check alone governs them.
+    if (
+      requestKey !== undefined &&
+      parsed.requestKey !== undefined &&
+      parsed.requestKey !== requestKey
+    ) {
+      return null;
     }
-    return null;
+    return parsed.data as DailyResponse;
   } catch {
     return null;
   }
@@ -133,11 +142,15 @@ export function getCachedDaily(): DailyResponse | null {
  * Production code should consume the cache via the `useFirstRunDaily`
  * hook — not via direct calls.
  */
-export function setCachedDaily(data: DailyResponse, cacheKey = dailyCacheKey()): void {
+export function setCachedDaily(
+  data: DailyResponse,
+  requestKey?: string,
+  cacheKey = dailyCacheKey(),
+): void {
   try {
     localStorage.setItem(
       'daily_horoscope_cache',
-      JSON.stringify({ date: cacheKey, data }),
+      JSON.stringify({ date: cacheKey, requestKey, data }),
     );
   } catch {
     // localStorage full or unavailable — ignore
@@ -300,8 +313,8 @@ export function useFirstRunDaily(
     //
     // Contract: callers who pass a NEW array reference (different
     // content) get a re-fetch with the new content — BUT only on a
-    // NEW target date (lastFetchedDateRef guard above short-circuits
-    // same-day re-fetches regardless of quiz content). Callers who
+    // NEW target date (lastFetchedRequestKeyRef guard above short-circuits
+    // same-request re-fetches regardless of quiz content). Callers who
     // mutate an array in place after render WITHOUT re-rendering get
     // undefined behavior — that's a React anti-pattern and we don't
     // support it.
@@ -406,7 +419,12 @@ export function useFirstRunDaily(
     // the hash was computed from. ESLint's exhaustive-deps no longer
     // fires because the body only reads the snapshots, not the live
     // refs, after effect entry.
-  }, [userId, birthData, soulprintSectorsKey, quizSectorsKey, birthSign, customDate, locale, retryTick]);
+    // `queuedFetchTick` MUST stay in this dep array: the finally block above
+    // bumps it when a queued follow-up request exists, which re-creates this
+    // callback and re-runs the mount effect so the queued fetch actually
+    // dispatches. Dropping it silently kills the queue mechanism (the bad
+    // merge that broke CI on 2026-05-17 did exactly that).
+  }, [userId, birthData, soulprintSectorsKey, quizSectorsKey, birthSign, customDate, locale, retryTick, queuedFetchTick]);
 
   const retry = useCallback(() => {
     // I-2 from the 2026-05-11 PR #343 review: retry() is a no-op when
@@ -458,9 +476,9 @@ export function useFirstRunDaily(
       // longer match anyway. Removing it explicitly keeps localStorage
       // tidy and avoids stale data lingering across user-tab visits.
       localStorage.removeItem('daily_horoscope_cache');
-      // Reset the dedupe ref so runDailyFetch's `targetDate ===
-      // lastFetchedDateRef.current` guard releases.
-      lastFetchedDateRef.current = null;
+      // Reset the dedupe ref so runDailyFetch's `requestKey ===
+      // lastFetchedRequestKeyRef.current` guard releases.
+      lastFetchedRequestKeyRef.current = null;
       // Reset state so consumers see the loading transition cleanly.
       setDailyData(null);
       // Trigger the refetch. No AbortSignal here — if the component


### PR DESCRIPTION
## Why main's Type Check is red

A merge around **2026-05-17** combined two parallel refactors of `src/hooks/useFirstRunDaily.ts` inconsistently. CI has been red on every main push since (visible from 05-27 onward; first red runs predate that).

Two TypeScript errors, both pointing at real runtime bugs that are live in production (Vite strips types without checking, so the broken code ships):

1. **TS2554 — `getCachedDaily(requestKey)` called with 1 arg, signature takes 0.** The merge kept the exported no-arg/day-window helper signatures from one branch and the `requestKey` call sites from the other (`ba33baa`). Runtime effect: the cache was written with the composite requestKey as its `date` field, so reads comparing against `dailyCacheKey()` **never hit — the daily-horoscope cache was dead**, every dashboard load refetched (extra LLM calls).

2. **TS2304 — `lastFetchedDateRef` undefined in the 06:00 listener.** The ref was renamed to `lastFetchedRequestKeyRef` but the 06:00 day-window listener kept the old name. Runtime effect: **the 06:00 timer threw an uncaught ReferenceError**, so the dashboard never rotated onto the new day-window without a page reload — defeating the feature's whole purpose.

3. (Found while fixing) The same merge **dropped `queuedFetchTick` from `runDailyFetch`'s dep array**, silently killing the queued-follow-up mechanism: dependency changes (locale, birth data) arriving while a fetch was in flight never dispatched their follow-up request.

## Fix

- Cache entries now store **both** the day-window date (preserves the tested 06:00 rotation contract) **and** the `requestKey` (preserves `ba33baa`'s intent: same-day input changes invalidate the cache). Legacy/seeded entries without a `requestKey` still match, so existing user caches degrade gracefully.
- Renamed the stale `lastFetchedDateRef` reference in the 06:00 listener.
- Restored `queuedFetchTick` to the dep array, with a comment explaining why it must stay.

## Verification

| Gate | Before | After |
|---|---|---|
| `npm run typecheck` (CI Type Check) | ❌ 2 errors | ✅ |
| `npm run lint` (tsc --noEmit) | ❌ | ✅ |
| `npx vitest run` | ❌ 7 failed / 2402 passed | ✅ 2 failed / 2407 passed |
| `npm run build` (CI Build, placeholder env) | ✅ | ✅ |
| `check:text-integrity`, `check:secrets` | ✅ | ✅ |

The 2 remaining test failures are **pre-existing server-side issues unrelated to this file** (not run by CI): `EDF-NCP-003` expects 502 but gets 503, and `api-daily-pulse` idempotency expects 200 but gets 422.

## Side finding: "pages build and deployment" failure

GitHub Pages is enabled on this repo (legacy Jekyll build of `main` root, custom domain `bazodiac.space`, status `errored`). It fails on every push because the repo is a Vite app, not a Jekyll site — and DNS for bazodiac.space points at Fastly (the real host), not GitHub Pages. The Pages config is obsolete; disabling it under Settings → Pages would remove that recurring red run. Not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix daily horoscope caching and fetch deduplication in useFirstRunDaily to repair CI type errors and runtime regressions.

New Features:
- Extend the daily horoscope cache to optionally key entries by a logical request identifier as well as the day-window date.

Bug Fixes:
- Correct cache reads and writes to be compatible with both legacy date-only entries and new request-keyed entries, restoring effective daily caching.
- Align the six a.m. rotation logic with the renamed deduplication ref so the scheduled day-window refresh no longer throws at runtime.
- Restore the queued follow-up fetch mechanism by including its tick in the main fetch effect dependencies.

Enhancements:
- Clarify documentation and inline comments around request-based deduplication, cache invariants, and the queued fetch mechanism in useFirstRunDaily.