### PR TITLE
fix: read fly secret names from lowercase json field

### DIFF
--- a/scripts/fly-preflight.mjs
+++ b/scripts/fly-preflight.mjs
@@ -35,7 +35,7 @@ function listFlySecrets(appName) {
 
 const appName = getFlyAppName();
 const secrets = listFlySecrets(appName);
-const secretNames = new Set(secrets.map((secret) => secret.Name));
+const secretNames = new Set(secrets.map((secret) => secret.name ?? secret.Name).filter(Boolean));
 const missing = requiredVars.filter((name) => !secretNames.has(name));
 
 if (missing.length > 0) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix preflight secret detection when Fly API returns secret objects with lowercase name fields.